### PR TITLE
实现隐藏菜单栏图标功能

### DIFF
--- a/Sources/UnclutterPlus/MainContentView.swift
+++ b/Sources/UnclutterPlus/MainContentView.swift
@@ -1,24 +1,68 @@
 import SwiftUI
+import Cocoa
+
+// 全局变量存储设置窗口控制器
+var preferencesWindowController: NSWindowController?
+
+func showPreferencesWindow() {
+    if preferencesWindowController == nil {
+        let hosting = NSHostingController(rootView: PreferencesView())
+        let window = NSWindow(contentViewController: hosting)
+        window.title = "Preferences"
+        window.styleMask = [.titled, .closable, .miniaturizable]
+        window.isReleasedWhenClosed = false
+        window.setFrameAutosaveName("UnclutterPlusPreferencesWindow")
+        window.setContentSize(NSSize(width: 520, height: 500))
+        window.center()
+        preferencesWindowController = NSWindowController(window: window)
+    }
+    
+    guard let windowController = preferencesWindowController,
+          let window = windowController.window else { return }
+    
+    NSApp.activate(ignoringOtherApps: true)
+    window.level = .floating
+    window.makeKeyAndOrderFront(nil)
+    windowController.showWindow(nil)
+}
 
 struct MainContentView: View {
     @State private var selectedTab = 0
     
     var body: some View {
         VStack(spacing: 0) {
-            // 标签页选择器
-            HStack(spacing: 0) {
-                TabButton(title: "Files", systemImage: "folder", isSelected: selectedTab == 0) {
-                    selectedTab = 0
+            // 标签页选择器区域
+            ZStack {
+                // 居中的标签页按钮
+                HStack(spacing: 0) {
+                    TabButton(title: "Files", systemImage: "folder", isSelected: selectedTab == 0) {
+                        selectedTab = 0
+                    }
+                    TabButton(title: "Clipboard", systemImage: "doc.on.clipboard", isSelected: selectedTab == 1) {
+                        selectedTab = 1
+                    }
+                    TabButton(title: "Notes", systemImage: "note.text", isSelected: selectedTab == 2) {
+                        selectedTab = 2
+                    }
                 }
-                TabButton(title: "Clipboard", systemImage: "doc.on.clipboard", isSelected: selectedTab == 1) {
-                    selectedTab = 1
-                }
-                TabButton(title: "Notes", systemImage: "note.text", isSelected: selectedTab == 2) {
-                    selectedTab = 2
+                
+                // 右侧的设置按钮
+                HStack {
+                    Spacer()
+                    Button(action: {
+                        // 直接创建并显示设置窗口
+                        showPreferencesWindow()
+                    }) {
+                        Image(systemName: "gearshape")
+                            .font(.system(size: 14, weight: .regular))
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Preferences")
                 }
             }
             .padding(.horizontal, 12)
-            .padding(.top, 8)
+            .padding(.vertical, 8)
             
             Divider()
             

--- a/Sources/UnclutterPlus/MarkdownPreferences.swift
+++ b/Sources/UnclutterPlus/MarkdownPreferences.swift
@@ -2,6 +2,11 @@ import Foundation
 import MarkdownUI
 import Splash
 
+// MARK: - Notification Names
+extension Notification.Name {
+    static let menuBarIconVisibilityChanged = Notification.Name("menuBarIconVisibilityChanged")
+}
+
 // MARK: - Markdown Theme Options
 enum MarkdownThemeOption: String, CaseIterable {
     case basic
@@ -85,6 +90,14 @@ final class Preferences: ObservableObject {
         didSet { save() }
     }
     
+    // Menu bar icon visibility
+    @Published var showMenuBarIcon: Bool {
+        didSet { 
+            save()
+            NotificationCenter.default.post(name: .menuBarIconVisibilityChanged, object: nil)
+        }
+    }
+    
     private init() {
         let defaults = UserDefaults.standard
         if let raw = defaults.string(forKey: "MarkdownThemeOption"),
@@ -112,6 +125,13 @@ final class Preferences: ObservableObject {
         // Load auto-save interval (default: 2.0 seconds)
         let savedInterval = defaults.double(forKey: "NotesAutoSaveInterval")
         notesAutoSaveInterval = savedInterval > 0 ? savedInterval : 2.0
+        
+        // Load menu bar icon visibility (default: true)
+        if defaults.object(forKey: "ShowMenuBarIcon") != nil {
+            showMenuBarIcon = defaults.bool(forKey: "ShowMenuBarIcon")
+        } else {
+            showMenuBarIcon = true
+        }
     }
     
     private func save() {
@@ -122,6 +142,7 @@ final class Preferences: ObservableObject {
         defaults.set(baseURLString, forKey: "MarkdownBaseURLString")
         defaults.set(mouseScrollMode.rawValue, forKey: "MouseScrollMode")
         defaults.set(notesAutoSaveInterval, forKey: "NotesAutoSaveInterval")
+        defaults.set(showMenuBarIcon, forKey: "ShowMenuBarIcon")
     }
 }
 

--- a/Sources/UnclutterPlus/PreferencesView.swift
+++ b/Sources/UnclutterPlus/PreferencesView.swift
@@ -44,6 +44,31 @@ struct PreferencesView: View {
                     .font(.footnote)
                     .foregroundColor(.secondary)
             }
+            
+            Section("Appearance") {
+                Toggle("Show menu bar icon", isOn: $prefs.showMenuBarIcon)
+                
+                if !prefs.showMenuBarIcon {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label("When menu bar icon is hidden:", systemImage: "info.circle")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                        
+                        Text("• Click Settings button in main window")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                        
+                        Text("• Right-click Dock icon for menu")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                        
+                        Text("• Swipe down at top edge to show window")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
 
             Section("Base URL") {
                 Toggle("Enable Base URL", isOn: $prefs.enableBaseURL)
@@ -56,6 +81,6 @@ struct PreferencesView: View {
             }
         }
         .padding(20)
-        .frame(width: 520)
+        .frame(width: 520, height: 500)
     }
 }


### PR DESCRIPTION
功能实现：
- 添加菜单栏图标显示/隐藏设置选项
  - 在 Preferences 中添加 showMenuBarIcon 属性
  - 实现动态显示/隐藏菜单栏图标
  - 使用通知机制同步状态变化

- 改进主窗口布局
  - 使用 ZStack 让三个功能模块保持居中
  - 设置按钮独立放置在右上角
  - 优化视觉层次和用户体验

- 添加多种访问设置的方式
  - 主窗口右上角设置按钮
  - Dock 图标右键菜单
  - 菜单栏图标菜单（当显示时）

- 实现 Dock 图标交互
  - 左键点击打开主窗口
  - 右键菜单包含设置和显示/隐藏菜单栏选项

- 修复设置窗口显示问题
  - 直接在 MainContentView 中创建设置窗口
  - 确保设置窗口能够正常显示和获得焦点