### PR TITLE
feat(剪贴板): 优化过滤工具栏与面板交互\n- 工具栏改为纯图标，点击后在下方划出面板\n- 类型/日期筛选改为单行横向芯片，选择后…

### DIFF
--- a/Sources/UnclutterPlus/AppDelegate.swift
+++ b/Sources/UnclutterPlus/AppDelegate.swift
@@ -69,7 +69,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     private func setupWindowManager() {
-        windowManager = WindowManager()
+        windowManager = WindowManager.shared
         print("WindowManager 已初始化")
     }
     
@@ -85,7 +85,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if self.preferencesWindowController == nil {
                 let hosting = NSHostingController(rootView: PreferencesView())
                 let window = NSWindow(contentViewController: hosting)
-                window.title = "Preferences"
+                window.title = "preferences.title".localized
                 window.styleMask = [.titled, .closable, .miniaturizable]
                 window.isReleasedWhenClosed = false
                 window.setFrameAutosaveName("UnclutterPlusPreferencesWindow")
@@ -101,6 +101,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             window.level = .floating
             window.makeKeyAndOrderFront(nil)
             windowController.showWindow(nil)
+            
+            // 设置模态窗口状态
+            WindowManager.shared.setModalWindow(true)
         }
     }
     
@@ -111,6 +114,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             name: .menuBarIconVisibilityChanged,
             object: nil
         )
+        
+        // 监听设置窗口关闭通知
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            if let window = notification.object as? NSWindow,
+               window == self?.preferencesWindowController?.window {
+                WindowManager.shared.setModalWindow(false)
+            }
+        }
     }
     
     @objc private func menuBarIconVisibilityChanged() {

--- a/Sources/UnclutterPlus/ClipboardManager.swift
+++ b/Sources/UnclutterPlus/ClipboardManager.swift
@@ -2,17 +2,83 @@ import Foundation
 import Cocoa
 import SwiftUI
 
-enum ClipboardContent: Hashable {
+enum ClipboardContent: Hashable, Codable {
+    enum CodingKeys: String, CodingKey {
+        case type, text, imageData, fileURL
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .text(let string):
+            try container.encode("text", forKey: .type)
+            try container.encode(string, forKey: .text)
+        case .image(let image):
+            try container.encode("image", forKey: .type)
+            if let tiffData = image.tiffRepresentation {
+                try container.encode(tiffData, forKey: .imageData)
+            }
+        case .file(let url):
+            try container.encode("file", forKey: .type)
+            try container.encode(url.path, forKey: .fileURL)
+        }
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        
+        switch type {
+        case "text":
+            let text = try container.decode(String.self, forKey: .text)
+            self = .text(text)
+        case "image":
+            if let imageData = try container.decodeIfPresent(Data.self, forKey: .imageData),
+               let image = NSImage(data: imageData) {
+                self = .image(image)
+            } else {
+                throw DecodingError.dataCorruptedError(forKey: .imageData, in: container, debugDescription: "Invalid image data")
+            }
+        case "file":
+            let path = try container.decode(String.self, forKey: .fileURL)
+            self = .file(URL(fileURLWithPath: path))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unknown type")
+        }
+    }
+    
     case text(String)
     case image(NSImage)
     case file(URL)
 }
 
-struct ClipboardItem: Identifiable, Hashable {
-    let id = UUID()
+struct ClipboardItem: Identifiable, Hashable, Codable {
+    let id: UUID
     let content: ClipboardContent
     let timestamp: Date
-    var isPinned: Bool = false
+    var isPinned: Bool
+    var useCount: Int
+    let sourceAppBundleID: String?
+    let sourceAppName: String?
+    let sourceAppIcon: Data?
+    
+    init(id: UUID = UUID(), 
+         content: ClipboardContent, 
+         timestamp: Date = Date(), 
+         isPinned: Bool = false,
+         useCount: Int = 0,
+         sourceAppBundleID: String? = nil,
+         sourceAppName: String? = nil,
+         sourceAppIcon: Data? = nil) {
+        self.id = id
+        self.content = content
+        self.timestamp = timestamp
+        self.isPinned = isPinned
+        self.useCount = useCount
+        self.sourceAppBundleID = sourceAppBundleID
+        self.sourceAppName = sourceAppName
+        self.sourceAppIcon = sourceAppIcon
+    }
     
     var systemImage: String {
         switch content {
@@ -53,6 +119,28 @@ struct ClipboardItem: Identifiable, Hashable {
     
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
+    }
+    
+    // 自定义解码器，处理向后兼容性
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        id = try container.decode(UUID.self, forKey: .id)
+        content = try container.decode(ClipboardContent.self, forKey: .content)
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+        isPinned = try container.decode(Bool.self, forKey: .isPinned)
+        
+        // 为 useCount 提供默认值，处理旧数据
+        useCount = try container.decodeIfPresent(Int.self, forKey: .useCount) ?? 0
+        
+        sourceAppBundleID = try container.decodeIfPresent(String.self, forKey: .sourceAppBundleID)
+        sourceAppName = try container.decodeIfPresent(String.self, forKey: .sourceAppName)
+        sourceAppIcon = try container.decodeIfPresent(Data.self, forKey: .sourceAppIcon)
+    }
+    
+    // 编码键
+    private enum CodingKeys: String, CodingKey {
+        case id, content, timestamp, isPinned, useCount, sourceAppBundleID, sourceAppName, sourceAppIcon
     }
 }
 
@@ -97,18 +185,33 @@ class ClipboardManager: ObservableObject {
     }
     
     private func captureClipboardContent() {
+        // 获取当前前台应用信息
+        let frontApp = NSWorkspace.shared.frontmostApplication
+        let bundleID = frontApp?.bundleIdentifier
+        let appName = frontApp?.localizedName
+        
+        // 获取应用图标
+        var iconData: Data? = nil
+        if let icon = frontApp?.icon {
+            if let tiffData = icon.tiffRepresentation,
+               let bitmapRep = NSBitmapImageRep(data: tiffData),
+               let pngData = bitmapRep.representation(using: .png, properties: [:]) {
+                iconData = pngData
+            }
+        }
+        
         // 优先级：文件 > 图片 > 文本
         if let urls = pasteboard.readObjects(forClasses: [NSURL.self]) as? [URL],
            let url = urls.first {
-            addItem(.file(url))
+            addItem(.file(url), sourceAppBundleID: bundleID, sourceAppName: appName, sourceAppIcon: iconData)
         } else if let image = pasteboard.readObjects(forClasses: [NSImage.self])?.first as? NSImage {
-            addItem(.image(image))
+            addItem(.image(image), sourceAppBundleID: bundleID, sourceAppName: appName, sourceAppIcon: iconData)
         } else if let string = pasteboard.string(forType: .string), !string.isEmpty {
-            addItem(.text(string))
+            addItem(.text(string), sourceAppBundleID: bundleID, sourceAppName: appName, sourceAppIcon: iconData)
         }
     }
     
-    private func addItem(_ content: ClipboardContent) {
+    private func addItem(_ content: ClipboardContent, sourceAppBundleID: String? = nil, sourceAppName: String? = nil, sourceAppIcon: Data? = nil) {
         // 检查是否已存在相同内容
         if let existingIndex = items.firstIndex(where: { item in
             switch (item.content, content) {
@@ -125,11 +228,26 @@ class ClipboardManager: ObservableObject {
             // 如果已存在，移动到顶部并更新时间戳
             let existingItem = items[existingIndex]
             items.remove(at: existingIndex)
-            let updatedItem = ClipboardItem(content: content, timestamp: Date(), isPinned: existingItem.isPinned)
+            let updatedItem = ClipboardItem(
+                content: content,
+                timestamp: Date(),
+                isPinned: existingItem.isPinned,
+                useCount: existingItem.useCount + 1,
+                sourceAppBundleID: sourceAppBundleID,
+                sourceAppName: sourceAppName,
+                sourceAppIcon: sourceAppIcon
+            )
             items.insert(updatedItem, at: 0)
         } else {
             // 新项目，插入到顶部
-            let item = ClipboardItem(content: content, timestamp: Date())
+            let item = ClipboardItem(
+                content: content,
+                timestamp: Date(),
+                isPinned: false,
+                sourceAppBundleID: sourceAppBundleID,
+                sourceAppName: sourceAppName,
+                sourceAppIcon: sourceAppIcon
+            )
             items.insert(item, at: 0)
             
             // 限制项目数量
@@ -151,6 +269,12 @@ class ClipboardManager: ObservableObject {
             pasteboard.writeObjects([image])
         case .file(let url):
             pasteboard.writeObjects([url as NSURL])
+        }
+        
+        // 增加使用频次
+        if let index = items.firstIndex(where: { $0.id == item.id }) {
+            items[index].useCount += 1
+            persistItems()
         }
         
         // 更新变更计数以避免重复捕获
@@ -194,38 +318,115 @@ class ClipboardManager: ObservableObject {
         persistItems()
     }
     
-    private func persistItems() {
-        // 获取存储路径
-        let storageURL = config.clipboardStoragePath.appendingPathComponent("history.plist")
+    // 清理过期数据
+    func cleanupExpiredItems() {
+        let maxAge = config.clipboardMaxAge
+        let cutoffDate = Date().addingTimeInterval(-maxAge)
         
-        // 只持久化文本内容（图片和文件太大）
-        let textItems = items.compactMap { item -> [String: Any]? in
-            switch item.content {
-            case .text(let text):
-                return [
-                    "type": "text",
-                    "content": text,
-                    "timestamp": item.timestamp.timeIntervalSince1970,
-                    "isPinned": item.isPinned
-                ]
-            default:
-                return nil
-            }
+        // 移除过期的非置顶项目
+        items.removeAll { item in
+            !item.isPinned && item.timestamp < cutoffDate
         }
         
-        // 保存到文件
+        persistItems()
+    }
+    
+    private func persistItems() {
+        // 获取存储路径
+        let storageURL = config.clipboardStoragePath.appendingPathComponent("history.json")
+        
+        // 创建存储目录（如果需要）
+        try? FileManager.default.createDirectory(at: config.clipboardStoragePath, withIntermediateDirectories: true)
+        
+        // 保存所有项目（包括图片和文件）
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        
+        // 限制保存的项目数量
+        let itemsToSave = Array(items.prefix(50))
+        
         do {
-            let data = try PropertyListSerialization.data(fromPropertyList: Array(textItems.prefix(50)), format: .xml, options: 0)
+            let data = try encoder.encode(itemsToSave)
             try data.write(to: storageURL)
         } catch {
             print("Failed to persist clipboard items: \(error)")
         }
+        
+        // 保存图片到单独的文件
+        saveImages()
+    }
+    
+    private func saveImages() {
+        let imagesPath = config.clipboardStoragePath.appendingPathComponent("images")
+        try? FileManager.default.createDirectory(at: imagesPath, withIntermediateDirectories: true)
+        
+        // 清理旧图片
+        if let files = try? FileManager.default.contentsOfDirectory(at: imagesPath, includingPropertiesForKeys: nil) {
+            for file in files {
+                try? FileManager.default.removeItem(at: file)
+            }
+        }
+        
+        // 保存当前图片
+        for item in items.prefix(20) { // 只保存前20个项目的图片
+            if case .image(let image) = item.content {
+                let imageURL = imagesPath.appendingPathComponent("\(item.id.uuidString).png")
+                if let tiffData = image.tiffRepresentation,
+                   let bitmapRep = NSBitmapImageRep(data: tiffData),
+                   let pngData = bitmapRep.representation(using: .png, properties: [:]) {
+                    try? pngData.write(to: imageURL)
+                }
+            }
+        }
     }
     
     private func loadPersistedItems() {
+        let storageURL = config.clipboardStoragePath.appendingPathComponent("history.json")
+        
+        // 尝试从新格式文件加载
+        if let data = try? Data(contentsOf: storageURL) {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            
+            if let loadedItems = try? decoder.decode([ClipboardItem].self, from: data) {
+                // 恢复图片
+                let imagesPath = config.clipboardStoragePath.appendingPathComponent("images")
+                var restoredItems: [ClipboardItem] = []
+                
+                for var item in loadedItems {
+                    if case .image = item.content {
+                        // 尝试从文件恢复图片
+                        let imageURL = imagesPath.appendingPathComponent("\(item.id.uuidString).png")
+                        if let imageData = try? Data(contentsOf: imageURL),
+                           let image = NSImage(data: imageData) {
+                            item = ClipboardItem(
+                                content: .image(image),
+                                timestamp: item.timestamp,
+                                isPinned: item.isPinned,
+                                useCount: item.useCount,
+                                sourceAppBundleID: item.sourceAppBundleID,
+                                sourceAppName: item.sourceAppName,
+                                sourceAppIcon: item.sourceAppIcon
+                            )
+                        } else {
+                            continue // 跳过无法恢复的图片
+                        }
+                    }
+                    restoredItems.append(item)
+                }
+                
+                items = restoredItems.sorted { $0.timestamp > $1.timestamp }
+                return
+            }
+        }
+        
+        // 尝试从旧格式文件加载（向后兼容）
+        loadLegacyItems()
+    }
+    
+    private func loadLegacyItems() {
         let storageURL = config.clipboardStoragePath.appendingPathComponent("history.plist")
         
-        // 尝试从文件加载
         if let data = try? Data(contentsOf: storageURL),
            let array = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [[String: Any]] {
             
@@ -235,18 +436,28 @@ class ClipboardManager: ObservableObject {
                       let timestamp = dict["timestamp"] as? TimeInterval,
                       type == "text" else {
                     return nil
-            }
-            
-            let isPinned = dict["isPinned"] as? Bool ?? false
-            
+                }
+                
+                let isPinned = dict["isPinned"] as? Bool ?? false
+                
                 return ClipboardItem(
                     content: .text(content),
                     timestamp: Date(timeIntervalSince1970: timestamp),
-                    isPinned: isPinned
+                    isPinned: isPinned,
+                    useCount: 0,
+                    sourceAppBundleID: nil,
+                    sourceAppName: nil,
+                    sourceAppIcon: nil
                 )
             }
             
             items = loadedItems.sorted { $0.timestamp > $1.timestamp }
+            
+            // 迁移到新格式
+            persistItems()
+            
+            // 删除旧文件
+            try? FileManager.default.removeItem(at: storageURL)
         }
     }
 }

--- a/Sources/UnclutterPlus/ClipboardView.swift
+++ b/Sources/UnclutterPlus/ClipboardView.swift
@@ -2,14 +2,72 @@ import SwiftUI
 
 struct ClipboardView: View {
     @StateObject private var clipboardManager = ClipboardManager()
+    @StateObject private var config = ConfigurationManager.shared
     @State private var searchText = ""
     @State private var selectedItems: Set<UUID> = []
     @State private var hoveredItem: UUID?
     @State private var isMultiSelectMode = false
     @State private var selectedIndex: Int = -1
     
+    // 过滤和排序状态
+    @State private var selectedContentType: String = "all" // "all", "text", "image", "file"
+    @State private var selectedSourceApp: String = "all"
+    @State private var selectedDateRange: String = "all" // "all", "today", "week", "month"
+    @State private var sortBy: String = "time" // "time", "useCount"
+    
+    // 过滤器展开状态
+    @State private var showTypeFilter: Bool = false
+    @State private var showSourceFilter: Bool = false
+    @State private var showDateFilter: Bool = false
+    @State private var showSortFilter: Bool = false
+    // 工具栏悬停状态
+    @State private var hoveredToolbar: String? = nil
+    
     var filteredItems: [ClipboardItem] {
         var items = clipboardManager.items
+        
+        // 内容类型过滤
+        if selectedContentType != "all" {
+            items = items.filter { item in
+                switch item.content {
+                case .text:
+                    return selectedContentType == "text"
+                case .image:
+                    return selectedContentType == "image"
+                case .file:
+                    return selectedContentType == "file"
+                }
+            }
+        }
+        
+        // 来源应用过滤
+        if selectedSourceApp != "all" {
+            items = items.filter { item in
+                item.sourceAppBundleID == selectedSourceApp
+            }
+        }
+        
+        // 日期范围过滤
+        if selectedDateRange != "all" {
+            let calendar = Calendar.current
+            let now = Date()
+            let cutoffDate: Date
+            
+            switch selectedDateRange {
+            case "today":
+                cutoffDate = calendar.startOfDay(for: now)
+            case "week":
+                cutoffDate = calendar.date(byAdding: .day, value: -7, to: now) ?? now
+            case "month":
+                cutoffDate = calendar.date(byAdding: .month, value: -1, to: now) ?? now
+            default:
+                cutoffDate = now
+            }
+            
+            items = items.filter { item in
+                item.timestamp >= cutoffDate
+            }
+        }
         
         // 搜索过滤
         if !searchText.isEmpty {
@@ -25,14 +83,19 @@ struct ClipboardView: View {
             }
         }
         
-        // 按置顶和时间排序
+        // 排序
         return items.sorted { first, second in
             if first.isPinned && !second.isPinned {
                 return true
             } else if !first.isPinned && second.isPinned {
                 return false
             } else {
-                return first.timestamp > second.timestamp
+                switch sortBy {
+                case "useCount":
+                    return first.useCount > second.useCount
+                default: // "time"
+                    return first.timestamp > second.timestamp
+                }
             }
         }
     }
@@ -46,7 +109,7 @@ struct ClipboardView: View {
                     Image(systemName: "magnifyingglass")
                         .foregroundColor(.secondary)
                     
-                    TextField("Search clipboard history...", text: $searchText)
+                    TextField("clipboard.search.placeholder".localized, text: $searchText)
                         .textFieldStyle(.plain)
                     
                     if !searchText.isEmpty {
@@ -59,7 +122,274 @@ struct ClipboardView: View {
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
-                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+                                                .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
+                
+                // 过滤和排序控件（仅图标按钮，点击后弹出选项）
+                HStack(spacing: 12) {
+                    // 类型
+                    Button(action: {
+                        if showTypeFilter { showTypeFilter = false } else {
+                            showTypeFilter = true
+                            showDateFilter = false
+                            showSourceFilter = false
+                            showSortFilter = false
+                        }
+                    }) {
+                        ZStack(alignment: .topTrailing) {
+                            Image(systemName: "doc.text")
+                                .font(.system(size: 13, weight: .semibold))
+                                .frame(width: 28, height: 28)
+                                .foregroundColor((selectedContentType != "all") ? .blue : (hoveredToolbar == "type" ? .primary : .primary))
+                                .background(
+                                    (selectedContentType != "all"
+                                        ? Color.blue.opacity(0.15)
+                                        : (hoveredToolbar == "type" ? Color.secondary.opacity(0.12) : Color.secondary.opacity(0.08))),
+                                    in: RoundedRectangle(cornerRadius: 6)
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .strokeBorder(
+                                            (selectedContentType != "all") ? Color.blue.opacity(0.4) : (hoveredToolbar == "type" ? Color.secondary.opacity(0.3) : Color.secondary.opacity(0.2)),
+                                            lineWidth: 1
+                                        )
+                                )
+                                .scaleEffect(hoveredToolbar == "type" ? 1.03 : 1.0)
+                                .animation(.easeInOut(duration: 0.12), value: hoveredToolbar == "type")
+                            if selectedContentType != "all" {
+                                Circle()
+                                    .fill(Color.blue)
+                                    .frame(width: 6, height: 6)
+                                    .offset(x: 2, y: -2)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { isHover in
+                        hoveredToolbar = isHover ? "type" : (hoveredToolbar == "type" ? nil : hoveredToolbar)
+                    }
+
+                    // 日期
+                    Button(action: {
+                        if showDateFilter { showDateFilter = false } else {
+                            showTypeFilter = false
+                            showDateFilter = true
+                            showSourceFilter = false
+                            showSortFilter = false
+                        }
+                    }) {
+                        ZStack(alignment: .topTrailing) {
+                            Image(systemName: "calendar")
+                                .font(.system(size: 13, weight: .semibold))
+                                .frame(width: 28, height: 28)
+                                .foregroundColor((selectedDateRange != "all") ? .red : (hoveredToolbar == "date" ? .primary : .primary))
+                                .background(
+                                    (selectedDateRange != "all"
+                                        ? Color.red.opacity(0.15)
+                                        : (hoveredToolbar == "date" ? Color.secondary.opacity(0.12) : Color.secondary.opacity(0.08))),
+                                    in: RoundedRectangle(cornerRadius: 6)
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .strokeBorder(
+                                            (selectedDateRange != "all") ? Color.red.opacity(0.4) : (hoveredToolbar == "date" ? Color.secondary.opacity(0.3) : Color.secondary.opacity(0.2)),
+                                            lineWidth: 1
+                                        )
+                                )
+                                .scaleEffect(hoveredToolbar == "date" ? 1.03 : 1.0)
+                                .animation(.easeInOut(duration: 0.12), value: hoveredToolbar == "date")
+                            if selectedDateRange != "all" {
+                                Circle()
+                                    .fill(Color.red)
+                                    .frame(width: 6, height: 6)
+                                    .offset(x: 2, y: -2)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { isHover in
+                        hoveredToolbar = isHover ? "date" : (hoveredToolbar == "date" ? nil : hoveredToolbar)
+                    }
+
+                    // 来源
+                    Button(action: {
+                        if showSourceFilter { showSourceFilter = false } else {
+                            showTypeFilter = false
+                            showDateFilter = false
+                            showSourceFilter = true
+                            showSortFilter = false
+                        }
+                    }) {
+                        ZStack(alignment: .topTrailing) {
+                            Image(systemName: "app.badge")
+                                .font(.system(size: 13, weight: .semibold))
+                                .frame(width: 28, height: 28)
+                                .foregroundColor((selectedSourceApp != "all") ? .purple : (hoveredToolbar == "source" ? .primary : .primary))
+                                .background(
+                                    (selectedSourceApp != "all"
+                                        ? Color.purple.opacity(0.15)
+                                        : (hoveredToolbar == "source" ? Color.secondary.opacity(0.12) : Color.secondary.opacity(0.08))),
+                                    in: RoundedRectangle(cornerRadius: 6)
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .strokeBorder(
+                                            (selectedSourceApp != "all") ? Color.purple.opacity(0.4) : (hoveredToolbar == "source" ? Color.secondary.opacity(0.3) : Color.secondary.opacity(0.2)),
+                                            lineWidth: 1
+                                        )
+                                )
+                                .scaleEffect(hoveredToolbar == "source" ? 1.03 : 1.0)
+                                .animation(.easeInOut(duration: 0.12), value: hoveredToolbar == "source")
+                            if selectedSourceApp != "all" {
+                                Circle()
+                                    .fill(Color.purple)
+                                    .frame(width: 6, height: 6)
+                                    .offset(x: 2, y: -2)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { isHover in
+                        hoveredToolbar = isHover ? "source" : (hoveredToolbar == "source" ? nil : hoveredToolbar)
+                    }
+
+                    Spacer()
+
+                    // 排序
+                    Button(action: {
+                        if showSortFilter { showSortFilter = false } else {
+                            showTypeFilter = false
+                            showDateFilter = false
+                            showSourceFilter = false
+                            showSortFilter = true
+                        }
+                    }) {
+                        ZStack(alignment: .topTrailing) {
+                            Image(systemName: "arrow.up.arrow.down")
+                                .font(.system(size: 13, weight: .semibold))
+                                .frame(width: 28, height: 28)
+                                .foregroundColor((sortBy != "time") ? .indigo : (hoveredToolbar == "sort" ? .primary : .primary))
+                                .background(
+                                    (sortBy != "time"
+                                        ? Color.indigo.opacity(0.15)
+                                        : (hoveredToolbar == "sort" ? Color.secondary.opacity(0.12) : Color.secondary.opacity(0.08))),
+                                    in: RoundedRectangle(cornerRadius: 6)
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .strokeBorder(
+                                            (sortBy != "time") ? Color.indigo.opacity(0.4) : (hoveredToolbar == "sort" ? Color.secondary.opacity(0.3) : Color.secondary.opacity(0.2)),
+                                            lineWidth: 1
+                                        )
+                                )
+                                .scaleEffect(hoveredToolbar == "sort" ? 1.03 : 1.0)
+                                .animation(.easeInOut(duration: 0.12), value: hoveredToolbar == "sort")
+                            if sortBy != "time" {
+                                Circle()
+                                    .fill(Color.indigo)
+                                    .frame(width: 6, height: 6)
+                                    .offset(x: 2, y: -2)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { isHover in
+                        hoveredToolbar = isHover ? "sort" : (hoveredToolbar == "sort" ? nil : hoveredToolbar)
+                    }
+                }
+                .padding(10)
+                .background(Color.secondary.opacity(0.05), in: RoundedRectangle(cornerRadius: 10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .strokeBorder(Color.secondary.opacity(0.1), lineWidth: 1)
+                )
+
+                // 下拉面板（在工具栏下方划出）
+                if showTypeFilter || showDateFilter || showSourceFilter || showSortFilter {
+                    HStack(alignment: .top, spacing: 0) {
+                        VStack(alignment: .leading, spacing: 10) {
+                        if showTypeFilter {
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: 8) {
+                                    FilterChip(title: "clipboard.filter.all".localized, icon: "square.grid.2x2", isSelected: selectedContentType == "all", color: .blue) { selectedContentType = "all"; showTypeFilter = false }
+                                    FilterChip(title: "clipboard.filter.text".localized, icon: "doc.plaintext", isSelected: selectedContentType == "text", color: .blue) { selectedContentType = "text"; showTypeFilter = false }
+                                    FilterChip(title: "clipboard.filter.image".localized, icon: "photo", isSelected: selectedContentType == "image", color: .green) { selectedContentType = "image"; showTypeFilter = false }
+                                    FilterChip(title: "clipboard.filter.file".localized, icon: "doc", isSelected: selectedContentType == "file", color: .orange) { selectedContentType = "file"; showTypeFilter = false }
+                                }
+                                .padding(.vertical, 2)
+                            }
+                        }
+
+                        if showDateFilter {
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: 8) {
+                                    FilterChip(title: "clipboard.filter.all".localized, icon: "calendar", isSelected: selectedDateRange == "all", color: .red) { selectedDateRange = "all"; showDateFilter = false }
+                                    FilterChip(title: "clipboard.filter.today".localized, icon: "sun.max", isSelected: selectedDateRange == "today", color: .red) { selectedDateRange = "today"; showDateFilter = false }
+                                    FilterChip(title: "clipboard.filter.week".localized, icon: "clock", isSelected: selectedDateRange == "week", color: .red) { selectedDateRange = "week"; showDateFilter = false }
+                                    FilterChip(title: "clipboard.filter.month".localized, icon: "calendar", isSelected: selectedDateRange == "month", color: .red) { selectedDateRange = "month"; showDateFilter = false }
+                                }
+                                .padding(.vertical, 2)
+                            }
+                        }
+
+                        if showSourceFilter {
+                            HStack(spacing: 8) {
+                                FilterChip(title: "clipboard.filter.all".localized, isSelected: selectedSourceApp == "all", color: .purple) { selectedSourceApp = "all" }
+                                ScrollView(.horizontal, showsIndicators: false) {
+                                    HStack(spacing: 8) {
+                                        ForEach(Array(Set(clipboardManager.items.compactMap { $0.sourceAppBundleID })).sorted(), id: \.self) { bundleID in
+                                            if let item = clipboardManager.items.first(where: { $0.sourceAppBundleID == bundleID }),
+                                               let iconData = item.sourceAppIcon,
+                                               let image = NSImage(data: iconData) {
+                                                Button(action: { selectedSourceApp = bundleID }) {
+                                                    Image(nsImage: image)
+                                                        .resizable()
+                                                        .aspectRatio(contentMode: .fit)
+                                                        .frame(width: 22, height: 22)
+                                                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                                                        .overlay(
+                                                            RoundedRectangle(cornerRadius: 5)
+                                                                .strokeBorder(
+                                                                    selectedSourceApp == bundleID ? Color.purple.opacity(0.6) : Color.secondary.opacity(0.3),
+                                                                    lineWidth: selectedSourceApp == bundleID ? 2 : 1
+                                                                )
+                                                        )
+                                                }
+                                                .buttonStyle(.plain)
+                                                .help(item.sourceAppName ?? bundleID)
+                                            }
+                                        }
+                                    }
+                                }
+                                Spacer()
+                                Button("common.cancel".localized) { showSourceFilter = false }
+                                    .buttonStyle(.borderless)
+                            }
+                        }
+
+                        if showSortFilter {
+                            HStack(spacing: 8) {
+                                SortButton(title: "clipboard.sort.time".localized, icon: "clock", isSelected: sortBy == "time") { sortBy = "time" }
+                                SortButton(title: "clipboard.sort.use_count".localized, icon: "number.circle", isSelected: sortBy == "useCount") { sortBy = "useCount" }
+                                Spacer()
+                                Button("common.cancel".localized) { showSortFilter = false }
+                                    .buttonStyle(.borderless)
+                            }
+                        }
+                        }
+                        .padding(10)
+                        .background(Color.secondary.opacity(0.05), in: RoundedRectangle(cornerRadius: 10))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .strokeBorder(Color.secondary.opacity(0.12), lineWidth: 1)
+                        )
+                        .frame(maxWidth: 420, alignment: .leading)
+                        Spacer()
+                    }
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                    .animation(.easeInOut(duration: 0.18), value: showTypeFilter || showDateFilter || showSourceFilter || showSortFilter)
+                }
+                
+                Spacer()
                 
                 // 多选模式切换
                 Button(action: {
@@ -72,7 +402,7 @@ struct ClipboardView: View {
                         .foregroundColor(isMultiSelectMode ? .accentColor : .secondary)
                 }
                 .buttonStyle(.plain)
-                .help(isMultiSelectMode ? "Exit selection mode" : "Enter selection mode")
+                .help(isMultiSelectMode ? "clipboard.multi_select.exit".localized : "clipboard.multi_select.enter".localized)
             }
             .padding(.horizontal, 12)
             .padding(.top, 12)
@@ -84,11 +414,11 @@ struct ClipboardView: View {
                         .font(.system(size: 48))
                         .foregroundColor(.secondary)
                     
-                    Text(searchText.isEmpty ? "No clipboard history" : "No matching items")
+                    Text(searchText.isEmpty ? "clipboard.empty.title".localized : "clipboard.empty.search.title".localized)
                         .font(.title2)
                         .foregroundColor(.secondary)
                     
-                    Text(searchText.isEmpty ? "Copy something to see it here" : "Try a different search term")
+                    Text(searchText.isEmpty ? "ui.copy_something_to_see".localized : "ui.try_different_search".localized)
                         .font(.caption)
                         .foregroundColor(.gray)
                         .multilineTextAlignment(.center)
@@ -104,7 +434,7 @@ struct ClipboardView: View {
                                 isSelected: selectedItems.contains(item.id),
                                 isHovered: hoveredItem == item.id,
                                 showSelectionMode: isMultiSelectMode,
-                                indexNumber: index < 9 ? index + 1 : nil
+                                indexNumber: nil
                             ) {
                                 // 复制操作
                                 copyItem(item)
@@ -127,7 +457,7 @@ struct ClipboardView: View {
             // 底部工具栏
             HStack {
                 if isMultiSelectMode && !selectedItems.isEmpty {
-                    Button("删除已选 (\(selectedItems.count))") {
+                    Button("clipboard.multi_select.delete_selected".localized + " (\(selectedItems.count))") {
                         let itemsToRemove = filteredItems.filter { selectedItems.contains($0.id) }
                         clipboardManager.removeItems(itemsToRemove)
                         selectedItems.removeAll()
@@ -135,7 +465,7 @@ struct ClipboardView: View {
                     .buttonStyle(.borderless)
                     .foregroundColor(.red)
                 } else {
-                    Button("清空全部") {
+                    Button("clipboard.multi_select.clear_all".localized) {
                         clipboardManager.clearAll()
                         selectedItems.removeAll()
                     }
@@ -144,7 +474,7 @@ struct ClipboardView: View {
                 
                 Spacer()
                 
-                Text("\(filteredItems.count) 项目")
+                Text("\(filteredItems.count) \("clipboard.multi_select.items".localized)")
                     .font(.caption)
                     .foregroundColor(.secondary)
                 
@@ -152,7 +482,7 @@ struct ClipboardView: View {
                     Text("|") 
                         .foregroundColor(.secondary)
                         .font(.caption)
-                    Text("\(selectedItems.count) 已选")
+                    Text("\(selectedItems.count) \("clipboard.multi_select.selected".localized)")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -167,6 +497,10 @@ struct ClipboardView: View {
     
     private func copyItem(_ item: ClipboardItem) {
         clipboardManager.copyToClipboard(item)
+        
+        // 触发自动隐藏窗口
+        WindowManager.shared.hideWindowAfterAction(.clipboardCopied)
+        
         // 显示复制反馈
         withAnimation(.easeInOut(duration: 0.2)) {
             // 可以添加视觉反馈
@@ -231,7 +565,7 @@ struct ClipboardItemView: View {
     
     var body: some View {
         HStack(spacing: 12) {
-            // 选择框/快捷索引
+            // 选择框/使用频次标签
             if showSelectionMode {
                 Button(action: onToggleSelection) {
                     Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
@@ -239,28 +573,21 @@ struct ClipboardItemView: View {
                         .font(.title3)
                 }
                 .buttonStyle(.plain)
-            } else if let number = indexNumber {
-                Text("\(number)")
-                    .font(.caption)
-                    .fontWeight(.bold)
+            } else {
+                // 使用频次标签
+                Text("\(item.useCount)")
+                    .font(.caption2)
+                    .fontWeight(.medium)
                     .foregroundColor(.secondary)
-                    .frame(width: 20, height: 20)
-                    .background(.tertiary, in: Circle())
+                    .frame(width: 24, height: 20)
+                    .background(.tertiary.opacity(0.5), in: RoundedRectangle(cornerRadius: 4))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .strokeBorder(.secondary.opacity(0.3), lineWidth: 0.5)
+                    )
             }
             
-            // 类型图标和状态
-            VStack(spacing: 2) {
-                Image(systemName: item.systemImage)
-                    .font(.title2)
-                    .foregroundColor(item.typeColor)
-                    .frame(width: 24)
-                
-                if item.isPinned {
-                    Image(systemName: "pin.fill")
-                        .font(.caption2)
-                        .foregroundColor(.orange)
-                }
-            }
+            // 内容预览
             
             // 内容预览
             VStack(alignment: .leading, spacing: 6) {
@@ -274,7 +601,7 @@ struct ClipboardItemView: View {
                             .textSelection(.enabled)
                         
                         if text.count > 100 {
-                            Button(showFullText ? "收起" : "展开") {
+                            Button(showFullText ? "clipboard.item.collapse".localized : "clipboard.item.expand".localized) {
                                 withAnimation(.easeInOut(duration: 0.2)) {
                                     showFullText.toggle()
                                 }
@@ -285,12 +612,37 @@ struct ClipboardItemView: View {
                         }
                     }
                 
-                case .image:
-                    HStack {
-                        Text("图片内容")
-                            .fontWeight(.medium)
-                            .foregroundColor(.secondary)
-                        Spacer()
+                case .image(let image):
+                    VStack(alignment: .leading, spacing: 8) {
+                        // 图片预览
+                        Image(nsImage: image)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxWidth: 200, maxHeight: 150)
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .strokeBorder(.secondary.opacity(0.3), lineWidth: 1)
+                            )
+                            .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
+                        
+                        // 图片信息
+                        HStack {
+                            Text("clipboard.item.image.content".localized)
+                                .fontWeight(.medium)
+                                .foregroundColor(.secondary)
+                            
+                            Spacer()
+                            
+                            // 显示图片尺寸
+                            let size = image.size
+                            Text("\(Int(size.width))×\(Int(size.height))")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(.tertiary.opacity(0.3), in: RoundedRectangle(cornerRadius: 4))
+                        }
                     }
                 
                 case .file(let url):
@@ -303,13 +655,54 @@ struct ClipboardItemView: View {
                 
                 // 时间戳和详情
                 HStack {
+                    // 类型图标和置顶状态
+                    HStack(spacing: 4) {
+                        Image(systemName: item.systemImage)
+                            .font(.caption)
+                            .foregroundColor(item.typeColor)
+                            .frame(width: 16)
+                        
+                        if item.isPinned {
+                            Image(systemName: "pin.fill")
+                                .font(.caption2)
+                                .foregroundColor(.orange)
+                        }
+                    }
+                    
+                    Text("•")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    
+                    // 来源应用信息
+                    if let appName = item.sourceAppName {
+                        HStack(spacing: 4) {
+                            if let iconData = item.sourceAppIcon,
+                               let image = NSImage(data: iconData) {
+                                Image(nsImage: image)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: 12, height: 12)
+                                    .clipShape(RoundedRectangle(cornerRadius: 2))
+                            }
+                            
+                            Text(appName)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .lineLimit(1)
+                        }
+                        
+                        Text("•")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    
                     Text(item.timestamp.formatted(.relative(presentation: .named)))
                         .font(.caption)
                         .foregroundColor(.secondary)
                     
                     if case .text(let text) = item.content {
                         Spacer()
-                        Text("\(text.count) 字符")
+                        Text("\(text.count) \("clipboard.item.characters".localized)")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
@@ -327,7 +720,7 @@ struct ClipboardItemView: View {
                             .foregroundColor(item.isPinned ? .orange : .secondary)
                     }
                     .buttonStyle(.borderless)
-                    .help(item.isPinned ? "取消置顶" : "置顶")
+                    .help(item.isPinned ? "clipboard.item.unpin".localized : "clipboard.item.pin".localized)
                     
                     Button(action: onCopy) {
                         Image(systemName: "doc.on.doc")
@@ -335,7 +728,7 @@ struct ClipboardItemView: View {
                             .foregroundColor(.accentColor)
                     }
                     .buttonStyle(.borderless)
-                    .help("复制到剪贴板")
+                    .help("clipboard.item.copy".localized)
                     
                     Button(action: onDelete) {
                         Image(systemName: "trash")
@@ -343,7 +736,7 @@ struct ClipboardItemView: View {
                             .foregroundColor(.red)
                     }
                     .buttonStyle(.borderless)
-                    .help("删除")
+                    .help("clipboard.item.delete".localized)
                 }
                 .transition(.opacity.combined(with: .scale))
             }
@@ -364,17 +757,17 @@ struct ClipboardItemView: View {
             }
         }
         .contextMenu {
-            Button(item.isPinned ? "取消置顶" : "置顶") {
+            Button(item.isPinned ? "clipboard.item.unpin".localized : "clipboard.item.pin".localized) {
                 onTogglePin()
             }
             
             Divider()
             
-            Button("复制") {
+            Button("clipboard.item.copy".localized) {
                 onCopy()
             }
             
-            Button("删除", role: .destructive) {
+            Button("clipboard.item.delete".localized, role: .destructive) {
                 onDelete()
             }
         }
@@ -386,7 +779,7 @@ struct ClipboardItemView: View {
         if isSelected {
             return .thick
         } else if item.isPinned {
-            return .regularMaterial
+            return .thinMaterial
         } else {
             return .thinMaterial
         }
@@ -454,6 +847,82 @@ class KeyHandlingNSView: NSView {
             return
         }
         super.keyDown(with: event)
+    }
+}
+
+// MARK: - Filter Components
+struct FilterChip: View {
+    let title: String
+    var icon: String? = nil
+    let isSelected: Bool
+    let color: Color
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 3) {
+                if let icon = icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 9))
+                }
+                Text(title)
+                    .font(.caption2)
+                    .fontWeight(.medium)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                isSelected ? color.opacity(0.15) : Color.secondary.opacity(0.08),
+                in: RoundedRectangle(cornerRadius: 6)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(
+                        isSelected ? color.opacity(0.4) : Color.secondary.opacity(0.2),
+                        lineWidth: isSelected ? 1.5 : 1
+                    )
+            )
+            .foregroundColor(isSelected ? color : .primary)
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isSelected ? 1.02 : 1.0)
+        .animation(.easeInOut(duration: 0.15), value: isSelected)
+    }
+}
+
+struct SortButton: View {
+    let title: String
+    let icon: String
+    let isSelected: Bool
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.system(size: 10))
+                Text(title)
+                    .font(.caption2)
+                    .fontWeight(.medium)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(
+                isSelected ? Color.indigo.opacity(0.15) : Color.secondary.opacity(0.08),
+                in: RoundedRectangle(cornerRadius: 8)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(
+                        isSelected ? Color.indigo.opacity(0.4) : Color.secondary.opacity(0.2),
+                        lineWidth: isSelected ? 1.5 : 1
+                    )
+            )
+            .foregroundColor(isSelected ? Color.indigo : .primary)
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isSelected ? 1.02 : 1.0)
+        .animation(.easeInOut(duration: 0.15), value: isSelected)
     }
 }
 

--- a/Sources/UnclutterPlus/ConfigurationManager.swift
+++ b/Sources/UnclutterPlus/ConfigurationManager.swift
@@ -19,6 +19,16 @@ class ConfigurationManager: ObservableObject {
     @AppStorage("storage.clipboard.useCustomPath") var useCustomClipboardPath: Bool = false
     @AppStorage("storage.notes.useCustomPath") var useCustomNotesPath: Bool = false
     
+    // 窗口自动隐藏设置
+    @AppStorage("window.autoHideAfterAction") var autoHideAfterAction: Bool = true
+    @AppStorage("window.hideOnLostFocus") var hideOnLostFocus: Bool = true
+    @AppStorage("window.hideDelay") var hideDelay: Double = 0.5
+    
+    // 剪贴板设置
+    @AppStorage("clipboard.maxAge") var clipboardMaxAge: TimeInterval = 30 * 24 * 60 * 60 // 30天
+    @AppStorage("clipboard.showUseCount") var showUseCount: Bool = true
+    @AppStorage("clipboard.sortBy") var clipboardSortBy: String = "time" // "time", "useCount"
+    
     private init() {}
     
     // 默认路径

--- a/Sources/UnclutterPlus/FilesView.swift
+++ b/Sources/UnclutterPlus/FilesView.swift
@@ -82,7 +82,7 @@ struct FilesView: View {
                 
                 // 排序选择
                 Menu {
-                    Section("Sort by") {
+                    Section("sort.by".localized) {
                         ForEach(SortOption.allCases, id: \.self) { option in
                             Button(action: { fileManager.sortOption = option }) {
                                 HStack {
@@ -100,7 +100,7 @@ struct FilesView: View {
                     
                     Button(action: { fileManager.isAscending.toggle() }) {
                         HStack {
-                            Text(fileManager.isAscending ? "Ascending" : "Descending")
+                            Text(fileManager.isAscending ? "sort.ascending".localized : "sort.descending".localized)
                             Spacer()
                             Image(systemName: fileManager.isAscending ? "arrow.up" : "arrow.down")
                         }
@@ -153,7 +153,7 @@ struct FilesView: View {
                             .font(.title2)
                             .foregroundColor(.secondary)
                         
-                        Text("Try a different search term")
+                        Text("ui.try_different_search".localized)
                             .font(.caption)
                             .foregroundColor(.gray)
                     }
@@ -229,6 +229,9 @@ struct FilesView: View {
         }
         .onDrop(of: [.fileURL], isTargeted: $dragOver) { providers in
             handleFileDrop(providers)
+        }
+        .onChange(of: dragOver) { _, isDragging in
+            WindowManager.shared.setDraggingFile(isDragging)
         }
         .onKeyDown { event in
             handleKeyDown(event)

--- a/Sources/UnclutterPlus/MainContentView.swift
+++ b/Sources/UnclutterPlus/MainContentView.swift
@@ -8,7 +8,7 @@ func showPreferencesWindow() {
     if preferencesWindowController == nil {
         let hosting = NSHostingController(rootView: PreferencesView())
         let window = NSWindow(contentViewController: hosting)
-        window.title = "Preferences"
+        window.title = "preferences.title".localized
         window.styleMask = [.titled, .closable, .miniaturizable]
         window.isReleasedWhenClosed = false
         window.setFrameAutosaveName("UnclutterPlusPreferencesWindow")
@@ -84,14 +84,14 @@ struct MainContentView: View {
                             .font(.system(size: 48))
                             .foregroundColor(.secondary)
                         
-                        Text("没有启用的功能")
+                        Text("features.no_enabled.title".localized)
                             .font(.title2)
                             .fontWeight(.semibold)
                         
-                        Text("请在设置中启用至少一个功能")
+                        Text("features.no_enabled.description".localized)
                             .foregroundColor(.secondary)
                         
-                        Button("打开设置") {
+                        Button("features.open_settings".localized) {
                             showPreferencesWindow()
                         }
                         .buttonStyle(.borderedProminent)
@@ -133,9 +133,9 @@ struct MainContentView: View {
         .onAppear {
             adjustSelectedTab()
         }
-        .onChange(of: config.isFilesEnabled) { adjustSelectedTab() }
-        .onChange(of: config.isClipboardEnabled) { adjustSelectedTab() }
-        .onChange(of: config.isNotesEnabled) { adjustSelectedTab() }
+        .onChange(of: config.isFilesEnabled) { _, _ in adjustSelectedTab() }
+        .onChange(of: config.isClipboardEnabled) { _, _ in adjustSelectedTab() }
+        .onChange(of: config.isNotesEnabled) { _, _ in adjustSelectedTab() }
     }
     
     // 获取启用的功能数量

--- a/Sources/UnclutterPlus/NoteEditorView.swift
+++ b/Sources/UnclutterPlus/NoteEditorView.swift
@@ -81,6 +81,9 @@ struct NoteEditorView: View {
                     .textFieldStyle(.plain)
                     .focused($isTitleFocused)
                     .onSubmit { saveNote() }
+                    .onChange(of: isTitleFocused) { oldValue, newValue in
+                        WindowManager.shared.setEditingNote(newValue)
+                    }
 
                 Spacer()
                 
@@ -89,7 +92,7 @@ struct NoteEditorView: View {
                     Label("\(note.wordCount)", systemImage: "textformat.abc")
                         .font(.caption)
                         .foregroundColor(.secondary)
-                        .help("\(note.wordCount) words, \(note.characterCount) characters")
+                        .help("\(note.wordCount) \("note.words".localized), \(note.characterCount) \("note.characters".localized)")
                     
                     if note.readingTime > 0 {
                         Label("\(note.readingTime) min", systemImage: "clock")
@@ -187,6 +190,9 @@ struct NoteEditorView: View {
                 saveNoteDebounced()
             }
             .focused($isContentFocused)
+            .onChange(of: isContentFocused) { oldValue, newValue in
+                WindowManager.shared.setEditingNote(newValue)
+            }
         }
         .padding()
     }
@@ -340,7 +346,7 @@ struct NoteEditorView: View {
     }
     
     private func saveNote() {
-        let newTitle = title.isEmpty ? "Untitled" : title
+                        let newTitle = title.isEmpty ? "note.untitled".localized : title
         if note.title != newTitle || note.content != content {
             isSaving = true
             

--- a/Sources/UnclutterPlus/NotesView.swift
+++ b/Sources/UnclutterPlus/NotesView.swift
@@ -32,7 +32,7 @@ struct NotesView: View {
                     Image(systemName: "magnifyingglass")
                         .foregroundColor(.secondary)
                     
-                    TextField("Search notes...", text: $notesManager.searchText)
+                    TextField("search.notes.placeholder".localized, text: $notesManager.searchText)
                         .textFieldStyle(.plain)
                 }
                 .padding(.horizontal, 10)
@@ -55,7 +55,7 @@ struct NotesView: View {
                 
                 // 排序和工具
                 Menu {
-                    Section("Sort by") {
+                    Section("sort.by".localized) {
                         ForEach(NotesSortOption.allCases, id: \.self) { option in
                             Button(action: { notesManager.sortOption = option }) {
                                 HStack {
@@ -73,7 +73,7 @@ struct NotesView: View {
                     
                     Button(action: { notesManager.isAscending.toggle() }) {
                         HStack {
-                            Text(notesManager.isAscending ? "Ascending" : "Descending")
+                            Text(notesManager.isAscending ? "sort.ascending".localized : "sort.descending".localized)
                             Spacer()
                             Image(systemName: notesManager.isAscending ? "arrow.up" : "arrow.down")
                         }
@@ -142,7 +142,7 @@ struct NotesView: View {
                 noteTags: $newNoteTags,
                 availableTags: notesManager.allTags,
                 onCreate: { title, tags in
-                    let note = notesManager.createNote(title: title.isEmpty ? "Untitled" : title, tags: tags)
+                    let note = notesManager.createNote(title: title.isEmpty ? "note.untitled".localized : title, tags: tags)
                     selectedNote = note
                     newNoteTitle = ""
                     newNoteTags.removeAll()
@@ -169,12 +169,12 @@ struct NotesView: View {
                 
                 // 统计信息
                 HStack {
-                    Text("\(notesManager.filteredNotes.count) notes")
+                    Text("\(notesManager.filteredNotes.count) \("notes.count".localized)")
                         .font(.caption)
                         .foregroundColor(.secondary)
                     
                     if !notesManager.searchText.isEmpty {
-                        Text("(已筛选)")
+                        Text("notes.filtered".localized)
                             .font(.caption)
                             .foregroundColor(.orange)
                     }
@@ -182,7 +182,7 @@ struct NotesView: View {
                     Spacer()
                     
                     if isMultiSelectMode && !notesManager.selectedNotes.isEmpty {
-                        Text("\(notesManager.selectedNotes.count) 已选")
+                        Text("\(notesManager.selectedNotes.count) \("notes.selected".localized)")
                             .font(.caption)
                             .foregroundColor(.accentColor)
                     }
@@ -199,17 +199,17 @@ struct NotesView: View {
                             .font(.system(size: 48))
                             .foregroundColor(.secondary)
                         
-                        Text(notesManager.searchText.isEmpty ? "No notes yet" : "No matching notes")
+                        Text(notesManager.searchText.isEmpty ? "notes.no_notes_yet".localized : "notes.no_matching_notes".localized)
                             .font(.title2)
                             .foregroundColor(.secondary)
                         
                         if notesManager.searchText.isEmpty {
-                            Button("Create First Note") {
+                            Button("ui.create_first_note".localized) {
                                 showingNewNoteDialog = true
                             }
                             .buttonStyle(.borderedProminent)
                         } else {
-                            Text("Try a different search term")
+                            Text("ui.try_different_search".localized)
                                 .font(.caption)
                                 .foregroundColor(.gray)
                         }
@@ -255,7 +255,7 @@ struct NotesView: View {
                 if isMultiSelectMode && !notesManager.selectedNotes.isEmpty {
                     Divider()
                     HStack {
-                        Button("删除已选 (\(notesManager.selectedNotes.count))") {
+                        Button("notes.delete_selected".localized + " (\(notesManager.selectedNotes.count))") {
                             let selectedNotes = notesManager.filteredNotes.filter { notesManager.selectedNotes.contains($0.id) }
                             notesManager.deleteNotes(selectedNotes)
                             if let selected = selectedNote, notesManager.selectedNotes.contains(selected.id) {
@@ -267,7 +267,7 @@ struct NotesView: View {
                         
                         Spacer()
                         
-                        Button("全选") {
+                        Button("notes.select_all".localized) {
                             notesManager.selectAll()
                         }
                         .buttonStyle(.borderless)
@@ -313,12 +313,12 @@ struct NotesView: View {
                             .font(.system(size: 56))
                             .foregroundColor(.secondary)
                         
-                        Text("Select a note to edit")
+                        Text("ui.select_note_to_edit".localized)
                             .font(.title)
                             .fontWeight(.semibold)
                             .foregroundColor(.secondary)
                         
-                        Text("Choose a note from the sidebar to get started")
+                        Text("ui.choose_note_from_sidebar".localized)
                             .font(.body)
                             .foregroundColor(.gray)
                             .multilineTextAlignment(.center)
@@ -345,17 +345,17 @@ struct NotesView: View {
                     .font(.system(size: 64))
                     .foregroundColor(.secondary)
                 
-                Text("Focus Mode")
+                Text("ui.focus_mode".localized)
                     .font(.largeTitle)
                     .fontWeight(.bold)
                     .foregroundColor(.primary)
                 
-                Text("Select a note from the toolbar to enter focus mode")
+                Text("ui.select_note_from_toolbar".localized)
                     .font(.title3)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
                 
-                Button("Browse Notes") {
+                Button("ui.browse_notes".localized) {
                     viewLayout = .sidebar
                 }
                 .buttonStyle(.borderedProminent)
@@ -447,7 +447,7 @@ struct NoteListItemView: View {
                         .font(.caption)
                         .foregroundColor(isSelected ? .white.opacity(0.8) : .gray)
                     
-                    Text("\(note.wordCount) words")
+                    Text("\(note.wordCount) \("note.words".localized)")
                         .font(.caption)
                         .foregroundColor(isSelected ? .white.opacity(0.8) : .gray)
                     
@@ -456,7 +456,7 @@ struct NoteListItemView: View {
                             .font(.caption)
                             .foregroundColor(isSelected ? .white.opacity(0.8) : .gray)
                         
-                        Text("\(note.readingTime) min read")
+                        Text("\(note.readingTime) \("note.min_read".localized)")
                             .font(.caption)
                             .foregroundColor(isSelected ? .white.opacity(0.8) : .gray)
                     }
@@ -533,11 +533,11 @@ struct NewNoteDialog: View {
     var body: some View {
         VStack(spacing: 24) {
             VStack(spacing: 8) {
-                Text("Create New Note")
+                Text("dialog.new_note.title".localized)
                     .font(.title2)
                     .fontWeight(.semibold)
                 
-                Text("Add a title and tags to organize your note")
+                Text("dialog.new_note.description".localized)
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
@@ -546,10 +546,10 @@ struct NewNoteDialog: View {
             VStack(alignment: .leading, spacing: 16) {
                 // 标题输入
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("Title")
+                    Text("dialog.new_note.title_label".localized)
                         .font(.headline)
                     
-                    TextField("Enter note title...", text: $noteTitle)
+                    TextField("dialog.new_note.title_placeholder".localized, text: $noteTitle)
                         .textFieldStyle(.roundedBorder)
                         .onSubmit {
                             onCreate(noteTitle, noteTags)
@@ -558,7 +558,7 @@ struct NewNoteDialog: View {
                 
                 // 标签选择
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Tags")
+                    Text("dialog.new_note.tags_label".localized)
                         .font(.headline)
                     
                     // 已选标签
@@ -575,7 +575,7 @@ struct NewNoteDialog: View {
                     
                     // 可用标签
                     if !availableTags.isEmpty {
-                        Text("Available Tags:")
+                        Text("dialog.new_note.available_tags".localized)
                             .font(.caption)
                             .foregroundColor(.secondary)
                         
@@ -592,7 +592,7 @@ struct NewNoteDialog: View {
                     
                     // 新标签输入
                     HStack {
-                        TextField("Add new tag...", text: $newTagName)
+                        TextField("dialog.new_note.add_new_tag_placeholder".localized, text: $newTagName)
                             .textFieldStyle(.roundedBorder)
                             .onSubmit {
                                 if !newTagName.isEmpty {
@@ -601,7 +601,7 @@ struct NewNoteDialog: View {
                                 }
                             }
                         
-                        Button("Add") {
+                        Button("dialog.new_note.add".localized) {
                             if !newTagName.isEmpty {
                                 noteTags.insert(newTagName.trimmingCharacters(in: .whitespacesAndNewlines))
                                 newTagName = ""
@@ -613,13 +613,13 @@ struct NewNoteDialog: View {
             }
             
             HStack(spacing: 16) {
-                Button("Cancel") {
+                Button("dialog.new_note.cancel".localized) {
                     onCancel()
                 }
                 .keyboardShortcut(.escape)
                 .controlSize(.large)
                 
-                Button("Create Note") {
+                Button("dialog.new_note.create".localized) {
                     onCreate(noteTitle, noteTags)
                 }
                 .keyboardShortcut(.return)
@@ -747,11 +747,11 @@ struct NewNoteButton: View {
                 }
                 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("新建笔记")
+                    Text("notes.new_note".localized)
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundColor(.primary)
                     
-                    Text("创建新的 Markdown 笔记")
+                    Text("notes.create_new_markdown".localized)
                         .font(.system(size: 11))
                         .foregroundColor(.secondary)
                 }

--- a/Sources/UnclutterPlus/PreferencesView.swift
+++ b/Sources/UnclutterPlus/PreferencesView.swift
@@ -89,6 +89,25 @@ struct PreferencesView: View {
                     .font(.footnote)
                     .foregroundColor(.secondary)
             }
+            
+            // 窗口行为设置
+            Section("preferences.section.window_behavior".localized) {
+                Toggle("preferences.window.auto_hide_after_action".localized, isOn: $config.autoHideAfterAction)
+                    .help("preferences.window.auto_hide_after_action.help".localized)
+                
+                Toggle("preferences.window.hide_on_lost_focus".localized, isOn: $config.hideOnLostFocus)
+                    .help("preferences.window.hide_on_lost_focus.help".localized)
+                
+                if config.autoHideAfterAction || config.hideOnLostFocus {
+                    HStack {
+                        Text("preferences.window.hide_delay".localized)
+                        Slider(value: $config.hideDelay, in: 0...2, step: 0.1)
+                            .frame(width: 200)
+                        Text("\(config.hideDelay, specifier: "%.1f") \("common.seconds".localized)")
+                            .frame(width: 60, alignment: .leading)
+                    }
+                }
+            }
         }
     }
     
@@ -188,6 +207,32 @@ struct PreferencesView: View {
                     usage: config.getStorageUsage(for: config.clipboardStoragePath),
                     showDefault: !config.useCustomClipboardPath
                 )
+                
+                // 剪贴板配置选项
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack {
+                        Text("preferences.clipboard.max_age".localized)
+                        Spacer()
+                        Text("\(Int(config.clipboardMaxAge / (24 * 60 * 60))) \("preferences.clipboard.days".localized)")
+                            .foregroundColor(.secondary)
+                            .monospacedDigit()
+                    }
+                    
+                    Slider(value: $config.clipboardMaxAge, in: 7 * 24 * 60 * 60...365 * 24 * 60 * 60, step: 24 * 60 * 60)
+                        .frame(width: 200)
+                    
+                    Text("preferences.clipboard.max_age_help".localized)
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                    
+                    Toggle("preferences.clipboard.show_use_count".localized, isOn: $config.showUseCount)
+                        .help("preferences.clipboard.show_use_count_help".localized)
+                    
+                    Toggle("preferences.clipboard.auto_cleanup".localized, isOn: .constant(true))
+                        .disabled(true)
+                        .help("preferences.clipboard.auto_cleanup_help".localized)
+                }
+                .padding(.top, 8)
             }
             
             // 笔记存储位置
@@ -348,8 +393,8 @@ struct PreferencesView: View {
         let alert = NSAlert()
         alert.messageText = "preferences.data.clear_confirm".localized
         alert.alertStyle = .warning
-        alert.addButton(withTitle: "OK")
-        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: "alert.ok".localized)
+        alert.addButton(withTitle: "common.cancel".localized)
         
         if let window = NSApp.keyWindow {
             alert.beginSheetModal(for: window) { response in
@@ -368,8 +413,8 @@ struct PreferencesView: View {
         let alert = NSAlert()
         alert.messageText = "preferences.data.reset_confirm".localized
         alert.alertStyle = .warning
-        alert.addButton(withTitle: "Reset")
-        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: "alert.reset".localized)
+        alert.addButton(withTitle: "common.cancel".localized)
         
         let resetAction = {
             self.config.resetToDefaults()

--- a/Sources/UnclutterPlus/Resources/de.lproj/Localizable.strings
+++ b/Sources/UnclutterPlus/Resources/de.lproj/Localizable.strings
@@ -81,10 +81,50 @@
 "files.contextmenu.delete" = "Löschen";
 
 // MARK: - Zwischenablage-Ansicht
-"clipboard.empty" = "Keine Zwischenablage-Historie";
-"clipboard.item.copied" = "Kopiert";
-"clipboard.contextmenu.copy" = "Kopieren";
-"clipboard.contextmenu.delete" = "Löschen";
+"clipboard.search.placeholder" = "Zwischenablage-Verlauf durchsuchen...";
+"clipboard.empty.title" = "Kein Zwischenablage-Verlauf";
+"clipboard.empty.search.title" = "Keine übereinstimmenden Elemente";
+"clipboard.item.image.content" = "Bildinhalt";
+"clipboard.item.image.dimensions" = "Abmessungen";
+"clipboard.item.characters" = "Zeichen";
+"clipboard.item.pin" = "Anheften";
+"clipboard.item.unpin" = "Lösen";
+"clipboard.item.copy" = "In Zwischenablage kopieren";
+"clipboard.item.delete" = "Löschen";
+"clipboard.item.expand" = "Erweitern";
+"clipboard.item.collapse" = "Einklappen";
+"clipboard.multi_select.enter" = "Auswahlmodus aktivieren";
+"clipboard.multi_select.exit" = "Auswahlmodus beenden";
+"clipboard.multi_select.delete_selected" = "Ausgewählte löschen";
+"clipboard.multi_select.clear_all" = "Alle löschen";
+"clipboard.multi_select.items" = "Elemente";
+"clipboard.multi_select.selected" = "ausgewählt";
+
+// MARK: - Zwischenablage-Filter
+"clipboard.filter.all" = "Alle";
+"clipboard.filter.text" = "Text";
+"clipboard.filter.image" = "Bild";
+"clipboard.filter.file" = "Datei";
+"clipboard.filter.today" = "Heute";
+"clipboard.filter.week" = "Diese Woche";
+"clipboard.filter.month" = "Diesen Monat";
+"clipboard.filter.type" = "Typ";
+"clipboard.filter.source" = "Quelle";
+"clipboard.filter.date" = "Datum";
+
+// MARK: - Zwischenablage-Sortierung
+"clipboard.sort.title" = "Sortieren";
+"clipboard.sort.time" = "Zeit";
+"clipboard.sort.use_count" = "Verwendungshäufigkeit";
+
+// MARK: - Zwischenablage-Einstellungen
+"preferences.clipboard.max_age" = "Maximale Aufbewahrungszeit:";
+"preferences.clipboard.days" = "Tage";
+"preferences.clipboard.max_age_help" = "Zwischenablage-Elemente, die älter als diese Zeit sind, werden automatisch entfernt (angeheftete Elemente werden beibehalten)";
+"preferences.clipboard.show_use_count" = "Verwendungshäufigkeit-Labels anzeigen";
+"preferences.clipboard.show_use_count_help" = "Verwendungshäufigkeit-Labels auf Zwischenablage-Elementen anzeigen";
+"preferences.clipboard.auto_cleanup" = "Automatische Bereinigung aktiviert";
+"preferences.clipboard.auto_cleanup_help" = "Abgelaufene Zwischenablage-Elemente automatisch entfernen";
 
 // MARK: - Notizen-Ansicht
 "notes.new" = "Neue Notiz";
@@ -113,3 +153,117 @@
 "common.delete" = "Löschen";
 "common.edit" = "Bearbeiten";
 "common.done" = "Fertig";
+
+// MARK: - Fensterverhalten-Einstellungen
+"preferences.section.window_behavior" = "Fensterverhalten";
+"preferences.window.auto_hide_after_action" = "Fenster nach Aktionen automatisch ausblenden";
+"preferences.window.auto_hide_after_action.help" = "Fenster automatisch ausblenden nach dem Öffnen von Dateien, Kopieren in die Zwischenablage, etc.";
+"preferences.window.hide_on_lost_focus" = "Bei Fokusverlust automatisch ausblenden";
+"preferences.window.hide_on_lost_focus.help" = "Fenster automatisch ausblenden, wenn es den Fokus verliert (außer beim Bearbeiten von Notizen)";
+"preferences.window.hide_delay" = "Ausblendverzögerung:";
+"common.seconds" = "Sekunden";
+
+// MARK: - Einstellungs-Tabs
+"preferences.tab.general" = "Allgemein";
+"preferences.tab.features" = "Funktionen";
+"preferences.tab.storage" = "Speicher";
+"preferences.tab.advanced" = "Erweitert";
+
+// MARK: - Einstellungs-Abschnitte
+"preferences.section.language" = "Sprache";
+"preferences.section.appearance" = "Erscheinungsbild";
+"preferences.section.interaction" = "Interaktion";
+"preferences.section.features" = "Funktionsschalter";
+"preferences.section.files" = "Dateien";
+"preferences.section.clipboard" = "Zwischenablage";
+"preferences.section.storage_location" = "Speicherorte";
+"preferences.section.data_management" = "Datenverwaltung";
+"preferences.section.developer" = "Entwickleroptionen";
+
+// MARK: - Funktionsschalter-Einstellungen
+"preferences.features.enable_files" = "Dateiverwaltung aktivieren";
+"preferences.features.enable_clipboard" = "Zwischenablage-Verlauf aktivieren";
+"preferences.features.enable_notes" = "Notizen-Funktion aktivieren";
+"preferences.features.description" = "Funktionen ein- oder ausschalten. Daten werden beibehalten, wenn Funktionen deaktiviert sind.";
+
+// MARK: - Speicher-Einstellungen
+"preferences.storage.custom_path" = "Benutzerdefinierten Pfad verwenden";
+"preferences.storage.choose_folder" = "Auswählen...";
+"preferences.storage.default_path" = "Standardpfad:";
+"preferences.storage.current_path" = "Aktueller Pfad:";
+"preferences.storage.space_used" = "Verwendeter Speicher:";
+"preferences.storage.files_location" = "Datei-Speicherort";
+"preferences.storage.clipboard_location" = "Zwischenablage-Speicherort";
+"preferences.storage.notes_location" = "Notizen-Speicherort";
+"preferences.storage.migrate_data" = "Daten migrieren";
+"preferences.storage.reset_paths" = "Auf Standard zurücksetzen";
+"preferences.storage.invalid_path" = "Ungültiger Pfad";
+"preferences.storage.path_not_writable" = "Der ausgewählte Pfad ist nicht beschreibbar. Bitte wählen Sie einen anderen Ort.";
+
+// MARK: - Datenverwaltung
+"preferences.data.clear_files" = "Alle Dateien löschen";
+"preferences.data.clear_clipboard" = "Zwischenablage-Verlauf löschen";
+"preferences.data.clear_notes" = "Alle Notizen löschen";
+"preferences.data.export" = "Daten exportieren";
+"preferences.data.import" = "Daten importieren";
+"preferences.data.reset_all" = "Alle Einstellungen zurücksetzen";
+"preferences.data.reset_confirm" = "Sind Sie sicher, dass Sie alle Einstellungen auf die Standardwerte zurücksetzen möchten?";
+"preferences.data.clear_confirm" = "Diese Aktion kann nicht rückgängig gemacht werden. Fortfahren?";
+
+// MARK: - Funktionsstatus
+"features.no_enabled.title" = "Keine Funktionen aktiviert";
+"features.no_enabled.description" = "Bitte aktivieren Sie mindestens eine Funktion in den Einstellungen";
+"features.open_settings" = "Einstellungen öffnen";
+
+// MARK: - Notizen-Ansicht zusätzlich
+"notes.filtered" = "(gefiltert)";
+"notes.selected" = "ausgewählt";
+"notes.delete_selected" = "Ausgewählte löschen";
+"notes.select_all" = "Alle auswählen";
+"notes.new_note" = "Neue Notiz";
+"notes.create_new_markdown" = "Neue Markdown-Notiz erstellen";
+
+// MARK: - Sortierung
+"sort.by" = "Sortieren nach";
+"sort.ascending" = "Aufsteigend";
+"sort.descending" = "Absteigend";
+
+// MARK: - Suche
+"search.notes.placeholder" = "Notizen suchen...";
+
+// MARK: - Neue Notiz-Dialog
+"dialog.new_note.title" = "Neue Notiz erstellen";
+"dialog.new_note.description" = "Fügen Sie einen Titel und Tags hinzu, um Ihre Notiz zu organisieren";
+"dialog.new_note.title_label" = "Titel";
+"dialog.new_note.title_placeholder" = "Notiz-Titel eingeben...";
+"dialog.new_note.tags_label" = "Tags";
+"dialog.new_note.available_tags" = "Verfügbare Tags:";
+"dialog.new_note.add_new_tag_placeholder" = "Neuen Tag hinzufügen...";
+"dialog.new_note.add" = "Hinzufügen";
+"dialog.new_note.cancel" = "Abbrechen";
+"dialog.new_note.create" = "Notiz erstellen";
+
+// MARK: - Gemeinsame Notiz
+"note.untitled" = "Unbenannt";
+
+// MARK: - Notizen-Statistiken
+"notes.count" = "Notizen";
+"notes.no_notes_yet" = "Noch keine Notizen";
+"notes.no_matching_notes" = "Keine übereinstimmenden Notizen";
+"note.words" = "Wörter";
+"note.min_read" = "Min. Lesezeit";
+"note.characters" = "Zeichen";
+
+// MARK: - UI-Nachrichten
+"ui.create_first_note" = "Erste Notiz erstellen";
+"ui.try_different_search" = "Versuchen Sie einen anderen Suchbegriff";
+"ui.select_note_to_edit" = "Wählen Sie eine Notiz zum Bearbeiten";
+"ui.choose_note_from_sidebar" = "Wählen Sie eine Notiz aus der Seitenleiste, um zu beginnen";
+"ui.focus_mode" = "Fokus-Modus";
+"ui.select_note_from_toolbar" = "Wählen Sie eine Notiz aus der Symbolleiste, um in den Fokus-Modus zu wechseln";
+"ui.browse_notes" = "Notizen durchsuchen";
+"ui.copy_something_to_see" = "Kopieren Sie etwas, um es hier zu sehen";
+
+// MARK: - Warnungs-Buttons
+"alert.ok" = "OK";
+"alert.reset" = "Zurücksetzen";

--- a/Sources/UnclutterPlus/Resources/en.lproj/Localizable.strings
+++ b/Sources/UnclutterPlus/Resources/en.lproj/Localizable.strings
@@ -122,10 +122,51 @@
 "files.contextmenu.delete" = "Delete";
 
 // MARK: - Clipboard View
-"clipboard.empty" = "No clipboard history";
-"clipboard.item.copied" = "Copied";
-"clipboard.contextmenu.copy" = "Copy";
-"clipboard.contextmenu.delete" = "Delete";
+"clipboard.search.placeholder" = "Search clipboard history...";
+"clipboard.empty.title" = "No clipboard history";
+"clipboard.empty.search.title" = "No matching items";
+"clipboard.item.image.content" = "Image content";
+"clipboard.item.image.dimensions" = "dimensions";
+"clipboard.item.characters" = "characters";
+"clipboard.item.pin" = "Pin";
+"clipboard.item.unpin" = "Unpin";
+"clipboard.item.copy" = "Copy to clipboard";
+"clipboard.item.delete" = "Delete";
+"clipboard.item.expand" = "Expand";
+"clipboard.item.collapse" = "Collapse";
+"clipboard.multi_select.enter" = "Enter selection mode";
+"clipboard.multi_select.exit" = "Exit selection mode";
+"clipboard.multi_select.delete_selected" = "Delete Selected";
+"clipboard.multi_select.clear_all" = "Clear All";
+"clipboard.multi_select.items" = "items";
+"clipboard.multi_select.selected" = "selected";
+
+// MARK: - Clipboard Filters
+"clipboard.filter.all" = "All";
+"clipboard.filter.text" = "Text";
+"clipboard.filter.image" = "Image";
+"clipboard.filter.file" = "File";
+"clipboard.filter.today" = "Today";
+"clipboard.filter.week" = "This Week";
+"clipboard.filter.month" = "This Month";
+"clipboard.filter.type" = "Type";
+"clipboard.filter.source" = "Source";
+"clipboard.filter.date" = "Date";
+"clipboard.filter.select_app" = "Select App";
+
+// MARK: - Clipboard Sorting
+"clipboard.sort.title" = "Sort";
+"clipboard.sort.time" = "Time";
+"clipboard.sort.use_count" = "Use Count";
+
+// MARK: - Clipboard Preferences
+"preferences.clipboard.max_age" = "Maximum retention period:";
+"preferences.clipboard.days" = "days";
+"preferences.clipboard.max_age_help" = "Clipboard items older than this will be automatically removed (pinned items are preserved)";
+"preferences.clipboard.show_use_count" = "Show use count labels";
+"preferences.clipboard.show_use_count_help" = "Display usage frequency labels on clipboard items";
+"preferences.clipboard.auto_cleanup" = "Auto-cleanup enabled";
+"preferences.clipboard.auto_cleanup_help" = "Automatically remove expired clipboard items";
 
 // MARK: - Notes View
 "notes.new" = "New Note";
@@ -154,3 +195,72 @@
 "common.delete" = "Delete";
 "common.edit" = "Edit";
 "common.done" = "Done";
+
+// MARK: - Window Behavior Settings
+"preferences.section.window_behavior" = "Window Behavior";
+"preferences.window.auto_hide_after_action" = "Auto-hide window after actions";
+"preferences.window.auto_hide_after_action.help" = "Automatically hide window after opening files, copying to clipboard, etc.";
+"preferences.window.hide_on_lost_focus" = "Auto-hide on lost focus";
+"preferences.window.hide_on_lost_focus.help" = "Automatically hide window when it loses focus (except when editing notes)";
+"preferences.window.hide_delay" = "Hide delay:";
+"common.seconds" = "seconds";
+
+// MARK: - Feature Status
+"features.no_enabled.title" = "No Features Enabled";
+"features.no_enabled.description" = "Please enable at least one feature in settings";
+"features.open_settings" = "Open Settings";
+
+// MARK: - Notes View Additional
+"notes.filtered" = "(filtered)";
+"notes.selected" = "selected";
+"notes.delete_selected" = "Delete Selected";
+"notes.select_all" = "Select All";
+"notes.new_note" = "New Note";
+"notes.create_new_markdown" = "Create new Markdown note";
+
+// MARK: - Sorting
+"sort.by" = "Sort by";
+"sort.ascending" = "Ascending";
+"sort.descending" = "Descending";
+
+// MARK: - UI Messages
+"ui.create_first_note" = "Create First Note";
+"ui.try_different_search" = "Try a different search term";
+"ui.select_note_to_edit" = "Select a note to edit";
+"ui.choose_note_from_sidebar" = "Choose a note from the sidebar to get started";
+"ui.focus_mode" = "Focus Mode";
+"ui.select_note_from_toolbar" = "Select a note from the toolbar to enter focus mode";
+"ui.browse_notes" = "Browse Notes";
+"ui.copy_something_to_see" = "Copy something to see it here";
+
+// MARK: - Note Statistics
+"note.words" = "words";
+"note.min_read" = "min read";
+"note.characters" = "characters";
+
+// MARK: - New Note Dialog
+"dialog.new_note.title" = "Create New Note";
+"dialog.new_note.description" = "Add a title and tags to organize your note";
+"dialog.new_note.title_label" = "Title";
+"dialog.new_note.title_placeholder" = "Enter note title...";
+"dialog.new_note.tags_label" = "Tags";
+"dialog.new_note.available_tags" = "Available Tags:";
+"dialog.new_note.add_new_tag_placeholder" = "Add new tag...";
+"dialog.new_note.add" = "Add";
+"dialog.new_note.cancel" = "Cancel";
+"dialog.new_note.create" = "Create Note";
+
+// MARK: - Common Note
+"note.untitled" = "Untitled";
+
+// MARK: - Notes Count
+"notes.count" = "notes";
+"notes.no_notes_yet" = "No notes yet";
+"notes.no_matching_notes" = "No matching notes";
+
+// MARK: - Search
+"search.notes.placeholder" = "Search notes...";
+
+// MARK: - Alert Buttons
+"alert.ok" = "OK";
+"alert.reset" = "Reset";

--- a/Sources/UnclutterPlus/Resources/es.lproj/Localizable.strings
+++ b/Sources/UnclutterPlus/Resources/es.lproj/Localizable.strings
@@ -113,3 +113,163 @@
 "common.delete" = "Eliminar";
 "common.edit" = "Editar";
 "common.done" = "Hecho";
+
+// MARK: - Configuración de comportamiento de ventana
+"preferences.section.window_behavior" = "Comportamiento de ventana";
+"preferences.window.auto_hide_after_action" = "Ocultar ventana automáticamente después de acciones";
+"preferences.window.auto_hide_after_action.help" = "Ocultar ventana automáticamente después de abrir archivos, copiar al portapapeles, etc.";
+"preferences.window.hide_on_lost_focus" = "Ocultar automáticamente al perder el foco";
+"preferences.window.hide_on_lost_focus.help" = "Ocultar ventana automáticamente cuando pierde el foco (excepto al editar notas)";
+"preferences.window.hide_delay" = "Retraso de ocultación:";
+"common.seconds" = "segundos";
+
+// MARK: - Pestañas de preferencias
+"preferences.tab.general" = "General";
+"preferences.tab.features" = "Características";
+"preferences.tab.storage" = "Almacenamiento";
+"preferences.tab.advanced" = "Avanzado";
+
+// MARK: - Secciones de preferencias
+"preferences.section.language" = "Idioma";
+"preferences.section.appearance" = "Apariencia";
+"preferences.section.interaction" = "Interacción";
+"preferences.section.features" = "Interruptores de características";
+"preferences.section.files" = "Archivos";
+"preferences.section.clipboard" = "Portapapeles";
+"preferences.section.storage_location" = "Ubicaciones de almacenamiento";
+"preferences.section.data_management" = "Gestión de datos";
+"preferences.section.developer" = "Opciones de desarrollador";
+
+// MARK: - Configuración de interruptores de características
+"preferences.features.enable_files" = "Habilitar gestión de archivos";
+"preferences.features.enable_clipboard" = "Habilitar historial del portapapeles";
+"preferences.features.enable_notes" = "Habilitar función de notas";
+"preferences.features.description" = "Activar o desactivar características. Los datos se conservan cuando las características están desactivadas.";
+
+// MARK: - Configuración de almacenamiento
+"preferences.storage.custom_path" = "Usar ruta personalizada";
+"preferences.storage.choose_folder" = "Elegir...";
+"preferences.storage.default_path" = "Ruta predeterminada:";
+"preferences.storage.current_path" = "Ruta actual:";
+"preferences.storage.space_used" = "Espacio usado:";
+"preferences.storage.files_location" = "Ubicación de almacenamiento de archivos";
+"preferences.storage.clipboard_location" = "Ubicación de almacenamiento del portapapeles";
+"preferences.storage.notes_location" = "Ubicación de almacenamiento de notas";
+"preferences.storage.migrate_data" = "Migrar datos";
+"preferences.storage.reset_paths" = "Restablecer a predeterminados";
+"preferences.storage.invalid_path" = "Ruta inválida";
+"preferences.storage.path_not_writable" = "La ruta seleccionada no es escribible. Por favor elija otra ubicación.";
+
+// MARK: - Gestión de datos
+"preferences.data.clear_files" = "Borrar todos los archivos";
+"preferences.data.clear_clipboard" = "Borrar historial del portapapeles";
+"preferences.data.clear_notes" = "Eliminar todas las notas";
+"preferences.data.export" = "Exportar datos";
+"preferences.data.import" = "Importar datos";
+"preferences.data.reset_all" = "Restablecer todas las configuraciones";
+"preferences.data.reset_confirm" = "¿Está seguro de que desea restablecer todas las configuraciones a los valores predeterminados?";
+"preferences.data.clear_confirm" = "Esta acción no se puede deshacer. ¿Continuar?";
+
+// MARK: - Estado de características
+"features.no_enabled.title" = "No hay características habilitadas";
+"features.no_enabled.description" = "Por favor habilite al menos una característica en la configuración";
+"features.open_settings" = "Abrir configuración";
+
+// MARK: - Vista de notas adicional
+"notes.filtered" = "(filtrado)";
+"notes.selected" = "seleccionado";
+"notes.delete_selected" = "Eliminar seleccionado";
+"notes.select_all" = "Seleccionar todo";
+"notes.new_note" = "Nueva nota";
+"notes.create_new_markdown" = "Crear nueva nota Markdown";
+
+// MARK: - Ordenamiento
+"sort.by" = "Ordenar por";
+"sort.ascending" = "Ascendente";
+"sort.descending" = "Descendente";
+
+// MARK: - Búsqueda
+"search.notes.placeholder" = "Buscar notas...";
+
+// MARK: - Diálogo nueva nota
+"dialog.new_note.title" = "Crear nueva nota";
+"dialog.new_note.description" = "Agregue un título y etiquetas para organizar su nota";
+"dialog.new_note.title_label" = "Título";
+"dialog.new_note.title_placeholder" = "Ingrese el título de la nota...";
+"dialog.new_note.tags_label" = "Etiquetas";
+"dialog.new_note.available_tags" = "Etiquetas disponibles:";
+"dialog.new_note.add_new_tag_placeholder" = "Agregar nueva etiqueta...";
+"dialog.new_note.add" = "Agregar";
+"dialog.new_note.cancel" = "Cancelar";
+"dialog.new_note.create" = "Crear nota";
+
+// MARK: - Nota común
+"note.untitled" = "Sin título";
+
+// MARK: - Estadísticas de notas
+"notes.count" = "notas";
+"notes.no_notes_yet" = "Aún no hay notas";
+"notes.no_matching_notes" = "No hay notas coincidentes";
+"note.words" = "palabras";
+"note.min_read" = "min de lectura";
+"note.characters" = "caracteres";
+
+// MARK: - Mensajes de UI
+"ui.create_first_note" = "Crear primera nota";
+"ui.try_different_search" = "Intente un término de búsqueda diferente";
+"ui.select_note_to_edit" = "Seleccione una nota para editar";
+"ui.choose_note_from_sidebar" = "Elija una nota de la barra lateral para comenzar";
+"ui.focus_mode" = "Modo de enfoque";
+"ui.select_note_from_toolbar" = "Seleccione una nota de la barra de herramientas para entrar en modo de enfoque";
+"ui.browse_notes" = "Explorar notas";
+"ui.copy_something_to_see" = "Copie algo para verlo aquí";
+
+// MARK: - Botones de alerta
+"alert.ok" = "OK";
+"alert.reset" = "Restablecer";
+
+// MARK: - Vista del Portapapeles
+"clipboard.search.placeholder" = "Buscar en el historial del portapapeles...";
+"clipboard.empty.title" = "Sin historial del portapapeles";
+"clipboard.empty.search.title" = "No hay elementos coincidentes";
+"clipboard.item.image.content" = "Contenido de imagen";
+"clipboard.item.image.dimensions" = "dimensiones";
+"clipboard.item.characters" = "caracteres";
+"clipboard.item.pin" = "Fijar";
+"clipboard.item.unpin" = "Desfijar";
+"clipboard.item.copy" = "Copiar al portapapeles";
+"clipboard.item.delete" = "Eliminar";
+"clipboard.item.expand" = "Expandir";
+"clipboard.item.collapse" = "Contraer";
+"clipboard.multi_select.enter" = "Entrar en modo selección";
+"clipboard.multi_select.exit" = "Salir del modo selección";
+"clipboard.multi_select.delete_selected" = "Eliminar seleccionados";
+"clipboard.multi_select.clear_all" = "Limpiar todo";
+"clipboard.multi_select.items" = "elementos";
+"clipboard.multi_select.selected" = "seleccionados";
+
+// MARK: - Filtros del Portapapeles
+"clipboard.filter.all" = "Todo";
+"clipboard.filter.text" = "Texto";
+"clipboard.filter.image" = "Imagen";
+"clipboard.filter.file" = "Archivo";
+"clipboard.filter.today" = "Hoy";
+"clipboard.filter.week" = "Esta semana";
+"clipboard.filter.month" = "Este mes";
+"clipboard.filter.type" = "Tipo";
+"clipboard.filter.source" = "Fuente";
+"clipboard.filter.date" = "Fecha";
+
+// MARK: - Ordenamiento del Portapapeles
+"clipboard.sort.title" = "Ordenar";
+"clipboard.sort.time" = "Tiempo";
+"clipboard.sort.use_count" = "Frecuencia de uso";
+
+// MARK: - Preferencias del Portapapeles
+"preferences.clipboard.max_age" = "Período de retención máximo:";
+"preferences.clipboard.days" = "días";
+"preferences.clipboard.max_age_help" = "Los elementos del portapapeles más antiguos que este período serán eliminados automáticamente (los elementos fijados se conservan)";
+"preferences.clipboard.show_use_count" = "Mostrar etiquetas de frecuencia de uso";
+"preferences.clipboard.show_use_count_help" = "Mostrar etiquetas de frecuencia de uso en elementos del portapapeles";
+"preferences.clipboard.auto_cleanup" = "Limpieza automática habilitada";
+"preferences.clipboard.auto_cleanup_help" = "Eliminar automáticamente elementos del portapapeles expirados";

--- a/Sources/UnclutterPlus/Resources/fr.lproj/Localizable.strings
+++ b/Sources/UnclutterPlus/Resources/fr.lproj/Localizable.strings
@@ -113,3 +113,163 @@
 "common.delete" = "Supprimer";
 "common.edit" = "Modifier";
 "common.done" = "Terminé";
+
+// MARK: - Paramètres de comportement de fenêtre
+"preferences.section.window_behavior" = "Comportement de la fenêtre";
+"preferences.window.auto_hide_after_action" = "Masquer automatiquement la fenêtre après les actions";
+"preferences.window.auto_hide_after_action.help" = "Masquer automatiquement la fenêtre après l'ouverture de fichiers, la copie dans le presse-papiers, etc.";
+"preferences.window.hide_on_lost_focus" = "Masquer automatiquement lors de la perte de focus";
+"preferences.window.hide_on_lost_focus.help" = "Masquer automatiquement la fenêtre lorsqu'elle perd le focus (sauf lors de l'édition de notes)";
+"preferences.window.hide_delay" = "Délai de masquage :";
+"common.seconds" = "secondes";
+
+// MARK: - Onglets des préférences
+"preferences.tab.general" = "Général";
+"preferences.tab.features" = "Fonctionnalités";
+"preferences.tab.storage" = "Stockage";
+"preferences.tab.advanced" = "Avancé";
+
+// MARK: - Sections des préférences
+"preferences.section.language" = "Langue";
+"preferences.section.appearance" = "Apparence";
+"preferences.section.interaction" = "Interaction";
+"preferences.section.features" = "Activation des fonctionnalités";
+"preferences.section.files" = "Fichiers";
+"preferences.section.clipboard" = "Presse-papiers";
+"preferences.section.storage_location" = "Emplacements de stockage";
+"preferences.section.data_management" = "Gestion des données";
+"preferences.section.developer" = "Options développeur";
+
+// MARK: - Activation des fonctionnalités
+"preferences.features.enable_files" = "Activer la gestion des fichiers";
+"preferences.features.enable_clipboard" = "Activer l'historique du presse-papiers";
+"preferences.features.enable_notes" = "Activer les notes";
+"preferences.features.description" = "Activez ou désactivez les fonctionnalités. Les données sont préservées lorsque les fonctionnalités sont désactivées.";
+
+// MARK: - Paramètres de stockage
+"preferences.storage.custom_path" = "Utiliser un chemin personnalisé";
+"preferences.storage.choose_folder" = "Choisir...";
+"preferences.storage.default_path" = "Chemin par défaut :";
+"preferences.storage.current_path" = "Chemin actuel :";
+"preferences.storage.space_used" = "Espace utilisé :";
+"preferences.storage.files_location" = "Emplacement de stockage des fichiers";
+"preferences.storage.clipboard_location" = "Emplacement de stockage du presse-papiers";
+"preferences.storage.notes_location" = "Emplacement de stockage des notes";
+"preferences.storage.migrate_data" = "Migrer les données";
+"preferences.storage.reset_paths" = "Réinitialiser aux valeurs par défaut";
+"preferences.storage.invalid_path" = "Chemin invalide";
+"preferences.storage.path_not_writable" = "Le chemin sélectionné n'est pas accessible en écriture. Veuillez choisir un autre emplacement.";
+
+// MARK: - Gestion des données
+"preferences.data.clear_files" = "Effacer tous les fichiers";
+"preferences.data.clear_clipboard" = "Effacer l'historique du presse-papiers";
+"preferences.data.clear_notes" = "Supprimer toutes les notes";
+"preferences.data.export" = "Exporter les données";
+"preferences.data.import" = "Importer les données";
+"preferences.data.reset_all" = "Réinitialiser tous les paramètres";
+"preferences.data.reset_confirm" = "Êtes-vous sûr de vouloir réinitialiser tous les paramètres aux valeurs par défaut ?";
+"preferences.data.clear_confirm" = "Cette action ne peut pas être annulée. Continuer ?";
+
+// MARK: - État des fonctionnalités
+"features.no_enabled.title" = "Aucune fonctionnalité activée";
+"features.no_enabled.description" = "Veuillez activer au moins une fonctionnalité dans les paramètres";
+"features.open_settings" = "Ouvrir les paramètres";
+
+// MARK: - Vue des notes supplémentaire
+"notes.filtered" = "(filtré)";
+"notes.selected" = "sélectionné";
+"notes.delete_selected" = "Supprimer la sélection";
+"notes.select_all" = "Tout sélectionner";
+"notes.new_note" = "Nouvelle note";
+"notes.create_new_markdown" = "Créer une nouvelle note Markdown";
+
+// MARK: - Tri
+"sort.by" = "Trier par";
+"sort.ascending" = "Croissant";
+"sort.descending" = "Décroissant";
+
+// MARK: - Recherche
+"search.notes.placeholder" = "Rechercher des notes...";
+
+// MARK: - Dialogue nouvelle note
+"dialog.new_note.title" = "Créer une nouvelle note";
+"dialog.new_note.description" = "Ajoutez un titre et des étiquettes pour organiser votre note";
+"dialog.new_note.title_label" = "Titre";
+"dialog.new_note.title_placeholder" = "Entrez le titre de la note...";
+"dialog.new_note.tags_label" = "Étiquettes";
+"dialog.new_note.available_tags" = "Étiquettes disponibles :";
+"dialog.new_note.add_new_tag_placeholder" = "Ajouter une nouvelle étiquette...";
+"dialog.new_note.add" = "Ajouter";
+"dialog.new_note.cancel" = "Annuler";
+"dialog.new_note.create" = "Créer la note";
+
+// MARK: - Note commune
+"note.untitled" = "Sans titre";
+
+// MARK: - Statistiques des notes
+"notes.count" = "notes";
+"notes.no_notes_yet" = "Aucune note pour le moment";
+"notes.no_matching_notes" = "Aucune note correspondante";
+"note.words" = "mots";
+"note.min_read" = "min de lecture";
+"note.characters" = "caractères";
+
+// MARK: - Messages UI
+"ui.create_first_note" = "Créer la première note";
+"ui.try_different_search" = "Essayez un autre terme de recherche";
+"ui.select_note_to_edit" = "Sélectionnez une note à éditer";
+"ui.choose_note_from_sidebar" = "Choisissez une note dans la barre latérale pour commencer";
+"ui.focus_mode" = "Mode focus";
+"ui.select_note_from_toolbar" = "Sélectionnez une note dans la barre d'outils pour entrer en mode focus";
+"ui.browse_notes" = "Parcourir les notes";
+"ui.copy_something_to_see" = "Copiez quelque chose pour le voir ici";
+
+// MARK: - Boutons d'alerte
+"alert.ok" = "OK";
+"alert.reset" = "Réinitialiser";
+
+// MARK: - Vue du Presse-papiers
+"clipboard.search.placeholder" = "Rechercher dans l'historique du presse-papiers...";
+"clipboard.empty.title" = "Aucun historique du presse-papiers";
+"clipboard.empty.search.title" = "Aucun élément correspondant";
+"clipboard.item.image.content" = "Contenu d'image";
+"clipboard.item.image.dimensions" = "dimensions";
+"clipboard.item.characters" = "caractères";
+"clipboard.item.pin" = "Épingler";
+"clipboard.item.unpin" = "Désépingler";
+"clipboard.item.copy" = "Copier dans le presse-papiers";
+"clipboard.item.delete" = "Supprimer";
+"clipboard.item.expand" = "Développer";
+"clipboard.item.collapse" = "Réduire";
+"clipboard.multi_select.enter" = "Entrer en mode sélection";
+"clipboard.multi_select.exit" = "Quitter le mode sélection";
+"clipboard.multi_select.delete_selected" = "Supprimer la sélection";
+"clipboard.multi_select.clear_all" = "Tout effacer";
+"clipboard.multi_select.items" = "éléments";
+"clipboard.multi_select.selected" = "sélectionnés";
+
+// MARK: - Filtres du Presse-papiers
+"clipboard.filter.all" = "Tout";
+"clipboard.filter.text" = "Texte";
+"clipboard.filter.image" = "Image";
+"clipboard.filter.file" = "Fichier";
+"clipboard.filter.today" = "Aujourd'hui";
+"clipboard.filter.week" = "Cette semaine";
+"clipboard.filter.month" = "Ce mois";
+"clipboard.filter.type" = "Type";
+"clipboard.filter.source" = "Source";
+"clipboard.filter.date" = "Date";
+
+// MARK: - Tri du Presse-papiers
+"clipboard.sort.title" = "Trier";
+"clipboard.sort.time" = "Temps";
+"clipboard.sort.use_count" = "Fréquence d'utilisation";
+
+// MARK: - Préférences du Presse-papiers
+"preferences.clipboard.max_age" = "Période de rétention maximale :";
+"preferences.clipboard.days" = "jours";
+"preferences.clipboard.max_age_help" = "Les éléments du presse-papiers plus anciens que cette période seront automatiquement supprimés (les éléments épinglés sont préservés)";
+"preferences.clipboard.show_use_count" = "Afficher les étiquettes de fréquence d'utilisation";
+"preferences.clipboard.show_use_count_help" = "Afficher les étiquettes de fréquence d'utilisation sur les éléments du presse-papiers";
+"preferences.clipboard.auto_cleanup" = "Nettoyage automatique activé";
+"preferences.clipboard.auto_cleanup_help" = "Supprimer automatiquement les éléments du presse-papiers expirés";

--- a/Sources/UnclutterPlus/Resources/ja.lproj/Localizable.strings
+++ b/Sources/UnclutterPlus/Resources/ja.lproj/Localizable.strings
@@ -85,6 +85,50 @@
 "clipboard.item.copied" = "コピー済み";
 "clipboard.contextmenu.copy" = "コピー";
 "clipboard.contextmenu.delete" = "削除";
+"clipboard.search.placeholder" = "クリップボード履歴を検索...";
+"clipboard.empty.title" = "クリップボード履歴がありません";
+"clipboard.empty.search.title" = "一致する項目がありません";
+"clipboard.item.image.content" = "画像コンテンツ";
+"clipboard.item.image.dimensions" = "サイズ";
+"clipboard.item.characters" = "文字";
+"clipboard.item.pin" = "ピン留め";
+"clipboard.item.unpin" = "ピン留め解除";
+"clipboard.item.copy" = "クリップボードにコピー";
+"clipboard.item.delete" = "削除";
+"clipboard.item.expand" = "展開";
+"clipboard.item.collapse" = "折りたたみ";
+"clipboard.multi_select.enter" = "選択モードに入る";
+"clipboard.multi_select.exit" = "選択モードを終了";
+"clipboard.multi_select.delete_selected" = "選択したものを削除";
+"clipboard.multi_select.clear_all" = "すべてクリア";
+"clipboard.multi_select.items" = "項目";
+"clipboard.multi_select.selected" = "選択済み";
+
+// MARK: - クリップボードフィルター
+"clipboard.filter.all" = "すべて";
+"clipboard.filter.text" = "テキスト";
+"clipboard.filter.image" = "画像";
+"clipboard.filter.file" = "ファイル";
+"clipboard.filter.today" = "今日";
+"clipboard.filter.week" = "今週";
+"clipboard.filter.month" = "今月";
+"clipboard.filter.type" = "タイプ";
+"clipboard.filter.source" = "ソース";
+"clipboard.filter.date" = "日付";
+
+// MARK: - クリップボードソート
+"clipboard.sort.title" = "ソート";
+"clipboard.sort.time" = "時間";
+"clipboard.sort.use_count" = "使用頻度";
+
+// MARK: - クリップボード設定
+"preferences.clipboard.max_age" = "最大保持期間：";
+"preferences.clipboard.days" = "日";
+"preferences.clipboard.max_age_help" = "この期間を超えたクリップボード項目は自動的に削除されます（ピン留めされた項目は保持されます）";
+"preferences.clipboard.show_use_count" = "使用頻度ラベルを表示";
+"preferences.clipboard.show_use_count_help" = "クリップボード項目に使用頻度ラベルを表示";
+"preferences.clipboard.auto_cleanup" = "自動クリーンアップが有効";
+"preferences.clipboard.auto_cleanup_help" = "期限切れのクリップボード項目を自動削除";
 
 // MARK: - メモビュー
 "notes.new" = "新しいメモ";
@@ -113,3 +157,117 @@
 "common.delete" = "削除";
 "common.edit" = "編集";
 "common.done" = "完了";
+
+// MARK: - ウィンドウ動作設定
+"preferences.section.window_behavior" = "ウィンドウ動作";
+"preferences.window.auto_hide_after_action" = "操作後にウィンドウを自動非表示";
+"preferences.window.auto_hide_after_action.help" = "ファイルを開く、クリップボードにコピーなどの操作後にウィンドウを自動的に非表示にします";
+"preferences.window.hide_on_lost_focus" = "フォーカスを失った時に自動非表示";
+"preferences.window.hide_on_lost_focus.help" = "ウィンドウがフォーカスを失った時に自動的に非表示にします（ノート編集中を除く）";
+"preferences.window.hide_delay" = "非表示遅延：";
+"common.seconds" = "秒";
+
+// MARK: - 設定タブ
+"preferences.tab.general" = "一般";
+"preferences.tab.features" = "機能";
+"preferences.tab.storage" = "ストレージ";
+"preferences.tab.advanced" = "詳細";
+
+// MARK: - 設定セクション
+"preferences.section.language" = "言語";
+"preferences.section.appearance" = "外観";
+"preferences.section.interaction" = "インタラクション";
+"preferences.section.features" = "機能切り替え";
+"preferences.section.files" = "ファイル";
+"preferences.section.clipboard" = "クリップボード";
+"preferences.section.storage_location" = "ストレージ場所";
+"preferences.section.data_management" = "データ管理";
+"preferences.section.developer" = "開発者オプション";
+
+// MARK: - 機能切り替え設定
+"preferences.features.enable_files" = "ファイル管理を有効にする";
+"preferences.features.enable_clipboard" = "クリップボード履歴を有効にする";
+"preferences.features.enable_notes" = "メモ機能を有効にする";
+"preferences.features.description" = "機能をオンまたはオフにします。機能を無効にしてもデータは保持されます。";
+
+// MARK: - ストレージ設定
+"preferences.storage.custom_path" = "カスタムパスを使用";
+"preferences.storage.choose_folder" = "選択...";
+"preferences.storage.default_path" = "デフォルトパス：";
+"preferences.storage.current_path" = "現在のパス：";
+"preferences.storage.space_used" = "使用容量：";
+"preferences.storage.files_location" = "ファイルストレージ場所";
+"preferences.storage.clipboard_location" = "クリップボードストレージ場所";
+"preferences.storage.notes_location" = "メモストレージ場所";
+"preferences.storage.migrate_data" = "データを移行";
+"preferences.storage.reset_paths" = "デフォルトにリセット";
+"preferences.storage.invalid_path" = "無効なパス";
+"preferences.storage.path_not_writable" = "選択されたパスは書き込み可能ではありません。別の場所を選択してください。";
+
+// MARK: - データ管理
+"preferences.data.clear_files" = "すべてのファイルをクリア";
+"preferences.data.clear_clipboard" = "クリップボード履歴をクリア";
+"preferences.data.clear_notes" = "すべてのメモを削除";
+"preferences.data.export" = "データをエクスポート";
+"preferences.data.import" = "データをインポート";
+"preferences.data.reset_all" = "すべての設定をリセット";
+"preferences.data.reset_confirm" = "すべての設定をデフォルトにリセットしてもよろしいですか？";
+"preferences.data.clear_confirm" = "この操作は元に戻せません。続行しますか？";
+
+// MARK: - 機能状態
+"features.no_enabled.title" = "有効な機能がありません";
+"features.no_enabled.description" = "設定で少なくとも1つの機能を有効にしてください";
+"features.open_settings" = "設定を開く";
+
+// MARK: - メモビュー追加
+"notes.filtered" = "(フィルター済み)";
+"notes.selected" = "選択済み";
+"notes.delete_selected" = "選択したものを削除";
+"notes.select_all" = "すべて選択";
+"notes.new_note" = "新しいメモ";
+"notes.create_new_markdown" = "新しいMarkdownメモを作成";
+
+// MARK: - 並び替え
+"sort.by" = "並び替え方法";
+"sort.ascending" = "昇順";
+"sort.descending" = "降順";
+
+// MARK: - 検索
+"search.notes.placeholder" = "メモを検索...";
+
+// MARK: - 新しいメモダイアログ
+"dialog.new_note.title" = "新しいメモを作成";
+"dialog.new_note.description" = "タイトルとタグを追加してメモを整理します";
+"dialog.new_note.title_label" = "タイトル";
+"dialog.new_note.title_placeholder" = "メモのタイトルを入力...";
+"dialog.new_note.tags_label" = "タグ";
+"dialog.new_note.available_tags" = "利用可能なタグ：";
+"dialog.new_note.add_new_tag_placeholder" = "新しいタグを追加...";
+"dialog.new_note.add" = "追加";
+"dialog.new_note.cancel" = "キャンセル";
+"dialog.new_note.create" = "メモを作成";
+
+// MARK: - 共通メモ
+"note.untitled" = "無題";
+
+// MARK: - メモ統計
+"notes.count" = "メモ";
+"notes.no_notes_yet" = "まだメモがありません";
+"notes.no_matching_notes" = "一致するメモがありません";
+"note.words" = "単語";
+"note.min_read" = "分で読了";
+"note.characters" = "文字";
+
+// MARK: - UIメッセージ
+"ui.create_first_note" = "最初のメモを作成";
+"ui.try_different_search" = "別の検索語を試してください";
+"ui.select_note_to_edit" = "編集するメモを選択";
+"ui.choose_note_from_sidebar" = "サイドバーからメモを選択して開始";
+"ui.focus_mode" = "フォーカスモード";
+"ui.select_note_from_toolbar" = "ツールバーからメモを選択してフォーカスモードに入る";
+"ui.browse_notes" = "メモを閲覧";
+"ui.copy_something_to_see" = "ここに表示するには何かをコピーしてください";
+
+// MARK: - 警告ボタン
+"alert.ok" = "OK";
+"alert.reset" = "リセット";

--- a/Sources/UnclutterPlus/Resources/ko.lproj/Localizable.strings
+++ b/Sources/UnclutterPlus/Resources/ko.lproj/Localizable.strings
@@ -81,10 +81,53 @@
 "files.contextmenu.delete" = "삭제";
 
 // MARK: - 클립보드 뷰
-"clipboard.empty" = "클립보드 기록이 없습니다";
+"clipboard.search.placeholder" = "클립보드 기록 검색...";
+"clipboard.empty.title" = "클립보드 기록이 없습니다";
+"clipboard.empty.search.title" = "일치하는 항목이 없습니다";
+"clipboard.item.image.content" = "이미지 내용";
+"clipboard.item.image.dimensions" = "크기";
+"clipboard.item.characters" = "문자";
+"clipboard.item.pin" = "고정";
+"clipboard.item.unpin" = "고정 해제";
+"clipboard.item.copy" = "클립보드에 복사";
+"clipboard.item.delete" = "삭제";
+"clipboard.item.expand" = "펼치기";
+"clipboard.item.collapse" = "접기";
+"clipboard.multi_select.enter" = "선택 모드 진입";
+"clipboard.multi_select.exit" = "선택 모드 종료";
+"clipboard.multi_select.delete_selected" = "선택된 항목 삭제";
+"clipboard.multi_select.clear_all" = "모두 지우기";
+"clipboard.multi_select.items" = "항목";
+"clipboard.multi_select.selected" = "선택됨";
 "clipboard.item.copied" = "복사됨";
 "clipboard.contextmenu.copy" = "복사";
 "clipboard.contextmenu.delete" = "삭제";
+
+// MARK: - 클립보드 필터
+"clipboard.filter.all" = "모두";
+"clipboard.filter.text" = "텍스트";
+"clipboard.filter.image" = "이미지";
+"clipboard.filter.file" = "파일";
+"clipboard.filter.today" = "오늘";
+"clipboard.filter.week" = "이번 주";
+"clipboard.filter.month" = "이번 달";
+"clipboard.filter.type" = "유형";
+"clipboard.filter.source" = "소스";
+"clipboard.filter.date" = "날짜";
+
+// MARK: - 클립보드 정렬
+"clipboard.sort.title" = "정렬";
+"clipboard.sort.time" = "시간";
+"clipboard.sort.use_count" = "사용 빈도";
+
+// MARK: - 클립보드 설정
+"preferences.clipboard.max_age" = "최대 보존 기간:";
+"preferences.clipboard.days" = "일";
+"preferences.clipboard.max_age_help" = "이 기간을 초과한 클립보드 항목은 자동으로 삭제됩니다 (고정된 항목은 보존됨)";
+"preferences.clipboard.show_use_count" = "사용 빈도 라벨 표시";
+"preferences.clipboard.show_use_count_help" = "클립보드 항목에 사용 빈도 라벨을 표시";
+"preferences.clipboard.auto_cleanup" = "자동 정리 활성화됨";
+"preferences.clipboard.auto_cleanup_help" = "만료된 클립보드 항목을 자동으로 삭제";
 
 // MARK: - 메모 뷰
 "notes.new" = "새 메모";
@@ -113,3 +156,117 @@
 "common.delete" = "삭제";
 "common.edit" = "편집";
 "common.done" = "완료";
+
+// MARK: - 윈도우 동작 설정
+"preferences.section.window_behavior" = "윈도우 동작";
+"preferences.window.auto_hide_after_action" = "작업 후 윈도우 자동 숨김";
+"preferences.window.auto_hide_after_action.help" = "파일 열기, 클립보드 복사 등의 작업 후 윈도우를 자동으로 숨깁니다";
+"preferences.window.hide_on_lost_focus" = "포커스 손실 시 자동 숨김";
+"preferences.window.hide_on_lost_focus.help" = "윈도우가 포커스를 잃을 때 자동으로 숨깁니다 (메모 편집 중 제외)";
+"preferences.window.hide_delay" = "숨김 지연:";
+"common.seconds" = "초";
+
+// MARK: - 환경설정 탭
+"preferences.tab.general" = "일반";
+"preferences.tab.features" = "기능";
+"preferences.tab.storage" = "저장소";
+"preferences.tab.advanced" = "고급";
+
+// MARK: - 환경설정 섹션
+"preferences.section.language" = "언어";
+"preferences.section.appearance" = "외관";
+"preferences.section.interaction" = "상호작용";
+"preferences.section.features" = "기능 토글";
+"preferences.section.files" = "파일";
+"preferences.section.clipboard" = "클립보드";
+"preferences.section.storage_location" = "저장 위치";
+"preferences.section.data_management" = "데이터 관리";
+"preferences.section.developer" = "개발자 옵션";
+
+// MARK: - 기능 토글 설정
+"preferences.features.enable_files" = "파일 관리 활성화";
+"preferences.features.enable_clipboard" = "클립보드 기록 활성화";
+"preferences.features.enable_notes" = "메모 기능 활성화";
+"preferences.features.description" = "기능을 켜거나 끕니다. 기능을 비활성화해도 데이터는 보존됩니다.";
+
+// MARK: - 저장소 설정
+"preferences.storage.custom_path" = "사용자 정의 경로 사용";
+"preferences.storage.choose_folder" = "선택...";
+"preferences.storage.default_path" = "기본 경로:";
+"preferences.storage.current_path" = "현재 경로:";
+"preferences.storage.space_used" = "사용된 공간:";
+"preferences.storage.files_location" = "파일 저장 위치";
+"preferences.storage.clipboard_location" = "클립보드 저장 위치";
+"preferences.storage.notes_location" = "메모 저장 위치";
+"preferences.storage.migrate_data" = "데이터 마이그레이션";
+"preferences.storage.reset_paths" = "기본값으로 재설정";
+"preferences.storage.invalid_path" = "잘못된 경로";
+"preferences.storage.path_not_writable" = "선택한 경로에 쓸 수 없습니다. 다른 위치를 선택하세요.";
+
+// MARK: - 데이터 관리
+"preferences.data.clear_files" = "모든 파일 지우기";
+"preferences.data.clear_clipboard" = "클립보드 기록 지우기";
+"preferences.data.clear_notes" = "모든 메모 삭제";
+"preferences.data.export" = "데이터 내보내기";
+"preferences.data.import" = "데이터 가져오기";
+"preferences.data.reset_all" = "모든 설정 재설정";
+"preferences.data.reset_confirm" = "모든 설정을 기본값으로 재설정하시겠습니까?";
+"preferences.data.clear_confirm" = "이 작업은 되돌릴 수 없습니다. 계속하시겠습니까?";
+
+// MARK: - 기능 상태
+"features.no_enabled.title" = "활성화된 기능이 없습니다";
+"features.no_enabled.description" = "설정에서 최소한 하나의 기능을 활성화하세요";
+"features.open_settings" = "설정 열기";
+
+// MARK: - 메모 뷰 추가
+"notes.filtered" = "(필터링됨)";
+"notes.selected" = "선택됨";
+"notes.delete_selected" = "선택된 항목 삭제";
+"notes.select_all" = "모두 선택";
+"notes.new_note" = "새 메모";
+"notes.create_new_markdown" = "새 Markdown 메모 생성";
+
+// MARK: - 정렬
+"sort.by" = "정렬 기준";
+"sort.ascending" = "오름차순";
+"sort.descending" = "내림차순";
+
+// MARK: - 검색
+"search.notes.placeholder" = "메모 검색...";
+
+// MARK: - 새 메모 대화상자
+"dialog.new_note.title" = "새 메모 생성";
+"dialog.new_note.description" = "제목과 태그를 추가하여 메모를 구성하세요";
+"dialog.new_note.title_label" = "제목";
+"dialog.new_note.title_placeholder" = "메모 제목 입력...";
+"dialog.new_note.tags_label" = "태그";
+"dialog.new_note.available_tags" = "사용 가능한 태그:";
+"dialog.new_note.add_new_tag_placeholder" = "새 태그 추가...";
+"dialog.new_note.add" = "추가";
+"dialog.new_note.cancel" = "취소";
+"dialog.new_note.create" = "메모 생성";
+
+// MARK: - 공통 메모
+"note.untitled" = "제목 없음";
+
+// MARK: - 메모 통계
+"notes.count" = "메모";
+"notes.no_notes_yet" = "아직 메모가 없습니다";
+"notes.no_matching_notes" = "일치하는 메모가 없습니다";
+"note.words" = "단어";
+"note.min_read" = "분 읽기";
+"note.characters" = "문자";
+
+// MARK: - UI 메시지
+"ui.create_first_note" = "첫 번째 메모 생성";
+"ui.try_different_search" = "다른 검색어를 시도해보세요";
+"ui.select_note_to_edit" = "편집할 메모를 선택하세요";
+"ui.choose_note_from_sidebar" = "사이드바에서 메모를 선택하여 시작하세요";
+"ui.focus_mode" = "포커스 모드";
+"ui.select_note_from_toolbar" = "도구 모음에서 메모를 선택하여 포커스 모드에 진입하세요";
+"ui.browse_notes" = "메모 찾아보기";
+"ui.copy_something_to_see" = "여기에서 보려면 무언가를 복사하세요";
+
+// MARK: - 경고 버튼
+"alert.ok" = "확인";
+"alert.reset" = "재설정";

--- a/Sources/UnclutterPlus/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/UnclutterPlus/Resources/zh-Hans.lproj/Localizable.strings
@@ -122,10 +122,51 @@
 "files.contextmenu.delete" = "删除";
 
 // MARK: - 剪贴板视图
-"clipboard.empty" = "无剪贴板历史";
-"clipboard.item.copied" = "已复制";
-"clipboard.contextmenu.copy" = "复制";
-"clipboard.contextmenu.delete" = "删除";
+"clipboard.search.placeholder" = "搜索剪贴板历史...";
+"clipboard.empty.title" = "无剪贴板历史";
+"clipboard.empty.search.title" = "没有匹配的项目";
+"clipboard.item.image.content" = "图片内容";
+"clipboard.item.image.dimensions" = "尺寸";
+"clipboard.item.characters" = "字符";
+"clipboard.item.pin" = "置顶";
+"clipboard.item.unpin" = "取消置顶";
+"clipboard.item.copy" = "复制到剪贴板";
+"clipboard.item.delete" = "删除";
+"clipboard.item.expand" = "展开";
+"clipboard.item.collapse" = "收起";
+"clipboard.multi_select.enter" = "进入选择模式";
+"clipboard.multi_select.exit" = "退出选择模式";
+"clipboard.multi_select.delete_selected" = "删除已选";
+"clipboard.multi_select.clear_all" = "清空全部";
+"clipboard.multi_select.items" = "项目";
+"clipboard.multi_select.selected" = "已选";
+
+// MARK: - 剪贴板过滤
+"clipboard.filter.all" = "全部";
+"clipboard.filter.text" = "文本";
+"clipboard.filter.image" = "图片";
+"clipboard.filter.file" = "文件";
+"clipboard.filter.today" = "今天";
+"clipboard.filter.week" = "本周";
+"clipboard.filter.month" = "本月";
+"clipboard.filter.type" = "类型";
+"clipboard.filter.source" = "来源";
+"clipboard.filter.date" = "日期";
+"clipboard.filter.select_app" = "选择应用";
+
+// MARK: - 剪贴板排序
+"clipboard.sort.title" = "排序";
+"clipboard.sort.time" = "时间";
+"clipboard.sort.use_count" = "使用频次";
+
+// MARK: - 剪贴板偏好设置
+"preferences.clipboard.max_age" = "最大保存时间：";
+"preferences.clipboard.days" = "天";
+"preferences.clipboard.max_age_help" = "超过此时间的剪贴板项目将被自动删除（置顶项目会被保留）";
+"preferences.clipboard.show_use_count" = "显示使用频次标签";
+"preferences.clipboard.show_use_count_help" = "在剪贴板项目上显示使用频次标签";
+"preferences.clipboard.auto_cleanup" = "自动清理已启用";
+"preferences.clipboard.auto_cleanup_help" = "自动删除过期的剪贴板项目";
 
 // MARK: - 笔记视图
 "notes.new" = "新建笔记";
@@ -154,3 +195,72 @@
 "common.delete" = "删除";
 "common.edit" = "编辑";
 "common.done" = "完成";
+
+// MARK: - 窗口行为设置
+"preferences.section.window_behavior" = "窗口行为";
+"preferences.window.auto_hide_after_action" = "操作后自动隐藏窗口";
+"preferences.window.auto_hide_after_action.help" = "执行文件打开、剪贴板复制等操作后自动隐藏窗口";
+"preferences.window.hide_on_lost_focus" = "失去焦点时自动隐藏";
+"preferences.window.hide_on_lost_focus.help" = "当窗口失去焦点时自动隐藏（编辑笔记时除外）";
+"preferences.window.hide_delay" = "隐藏延迟：";
+"common.seconds" = "秒";
+
+// MARK: - 功能状态
+"features.no_enabled.title" = "没有启用的功能";
+"features.no_enabled.description" = "请在设置中启用至少一个功能";
+"features.open_settings" = "打开设置";
+
+// MARK: - 笔记视图补充
+"notes.filtered" = "(已筛选)";
+"notes.selected" = "已选";
+"notes.delete_selected" = "删除已选";
+"notes.select_all" = "全选";
+"notes.new_note" = "新建笔记";
+"notes.create_new_markdown" = "创建新的 Markdown 笔记";
+
+// MARK: - 排序
+"sort.by" = "排序方式";
+"sort.ascending" = "升序";
+"sort.descending" = "降序";
+
+// MARK: - 界面消息
+"ui.create_first_note" = "创建第一条笔记";
+"ui.try_different_search" = "尝试不同的搜索词";
+"ui.select_note_to_edit" = "选择笔记进行编辑";
+"ui.choose_note_from_sidebar" = "从侧边栏选择笔记开始";
+"ui.focus_mode" = "专注模式";
+"ui.select_note_from_toolbar" = "从工具栏选择笔记进入专注模式";
+"ui.browse_notes" = "浏览笔记";
+"ui.copy_something_to_see" = "复制一些内容以在此处查看";
+
+// MARK: - 笔记统计
+"note.words" = "字";
+"note.min_read" = "分钟阅读";
+"note.characters" = "字符";
+
+// MARK: - 新建笔记对话框
+"dialog.new_note.title" = "创建新笔记";
+"dialog.new_note.description" = "添加标题和标签来组织您的笔记";
+"dialog.new_note.title_label" = "标题";
+"dialog.new_note.title_placeholder" = "输入笔记标题...";
+"dialog.new_note.tags_label" = "标签";
+"dialog.new_note.available_tags" = "可用标签：";
+"dialog.new_note.add_new_tag_placeholder" = "添加新标签...";
+"dialog.new_note.add" = "添加";
+"dialog.new_note.cancel" = "取消";
+"dialog.new_note.create" = "创建笔记";
+
+// MARK: - 通用笔记
+"note.untitled" = "无标题";
+
+// MARK: - 笔记数量
+"notes.count" = "笔记";
+"notes.no_notes_yet" = "还没有笔记";
+"notes.no_matching_notes" = "没有匹配的笔记";
+
+// MARK: - 搜索
+"search.notes.placeholder" = "搜索笔记...";
+
+// MARK: - 警告框按钮
+"alert.ok" = "确定";
+"alert.reset" = "重置";

--- a/Sources/UnclutterPlus/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/UnclutterPlus/Resources/zh-Hant.lproj/Localizable.strings
@@ -113,3 +113,164 @@
 "common.delete" = "刪除";
 "common.edit" = "編輯";
 "common.done" = "完成";
+
+// MARK: - 視窗行為設定
+"preferences.section.window_behavior" = "視窗行為";
+"preferences.window.auto_hide_after_action" = "操作後自動隱藏視窗";
+"preferences.window.auto_hide_after_action.help" = "執行檔案開啟、剪貼簿複製等操作後自動隱藏視窗";
+"preferences.window.hide_on_lost_focus" = "失去焦點時自動隱藏";
+"preferences.window.hide_on_lost_focus.help" = "當視窗失去焦點時自動隱藏（編輯筆記時除外）";
+"preferences.window.hide_delay" = "隱藏延遲：";
+"common.seconds" = "秒";
+
+// MARK: - 設定標籤頁
+"preferences.tab.general" = "一般";
+"preferences.tab.features" = "功能";
+"preferences.tab.storage" = "儲存";
+"preferences.tab.advanced" = "進階";
+
+// MARK: - 設定分組
+"preferences.section.language" = "語言";
+"preferences.section.appearance" = "外觀";
+"preferences.section.interaction" = "互動";
+"preferences.section.features" = "功能開關";
+"preferences.section.files" = "檔案";
+"preferences.section.clipboard" = "剪貼簿";
+"preferences.section.storage_location" = "儲存位置";
+"preferences.section.data_management" = "資料管理";
+"preferences.section.developer" = "開發者選項";
+
+// MARK: - 功能開關設定
+"preferences.features.enable_files" = "啟用檔案管理";
+"preferences.features.enable_clipboard" = "啟用剪貼簿歷史";
+"preferences.features.enable_notes" = "啟用筆記功能";
+"preferences.features.description" = "開啟或關閉功能。關閉功能後資料不會被刪除。";
+
+// MARK: - 儲存設定
+"preferences.storage.custom_path" = "使用自訂路徑";
+"preferences.storage.choose_folder" = "選擇...";
+"preferences.storage.default_path" = "預設路徑：";
+"preferences.storage.current_path" = "目前路徑：";
+"preferences.storage.space_used" = "已用空間：";
+"preferences.storage.files_location" = "檔案儲存位置";
+"preferences.storage.clipboard_location" = "剪貼簿儲存位置";
+"preferences.storage.notes_location" = "筆記儲存位置";
+"preferences.storage.migrate_data" = "移轉資料";
+"preferences.storage.reset_paths" = "重設為預設";
+"preferences.storage.invalid_path" = "無效的路徑";
+"preferences.storage.path_not_writable" = "所選路徑不可寫。請選擇另一個位置。";
+
+// MARK: - 資料管理
+"preferences.data.clear_files" = "清除所有檔案";
+"preferences.data.clear_clipboard" = "清除剪貼簿歷史";
+"preferences.data.clear_notes" = "刪除所有筆記";
+"preferences.data.export" = "匯出資料";
+"preferences.data.import" = "匯入資料";
+"preferences.data.reset_all" = "重設所有設定";
+"preferences.data.reset_confirm" = "確定要將所有設定重設為預設值嗎？";
+"preferences.data.clear_confirm" = "此操作無法復原。是否繼續？";
+
+// MARK: - 功能狀態
+"features.no_enabled.title" = "沒有啟用的功能";
+"features.no_enabled.description" = "請在設定中啟用至少一個功能";
+"features.open_settings" = "開啟設定";
+
+// MARK: - 筆記檢視補充
+"notes.filtered" = "(已篩選)";
+"notes.selected" = "已選";
+"notes.delete_selected" = "刪除已選";
+"notes.select_all" = "全選";
+"notes.new_note" = "新增筆記";
+"notes.create_new_markdown" = "建立新的 Markdown 筆記";
+
+// MARK: - 排序
+"sort.by" = "排序方式";
+"sort.ascending" = "升序";
+"sort.descending" = "降序";
+
+// MARK: - 搜尋
+"search.notes.placeholder" = "搜尋筆記...";
+
+// MARK: - 新增筆記對話框
+"dialog.new_note.title" = "建立新筆記";
+"dialog.new_note.description" = "新增標題和標籤來組織您的筆記";
+"dialog.new_note.title_label" = "標題";
+"dialog.new_note.title_placeholder" = "輸入筆記標題...";
+"dialog.new_note.tags_label" = "標籤";
+"dialog.new_note.available_tags" = "可用標籤：";
+"dialog.new_note.add_new_tag_placeholder" = "新增新標籤...";
+"dialog.new_note.add" = "新增";
+"dialog.new_note.cancel" = "取消";
+"dialog.new_note.create" = "建立筆記";
+
+// MARK: - 通用筆記
+"note.untitled" = "無標題";
+
+// MARK: - 筆記數量
+"notes.count" = "筆記";
+"notes.no_notes_yet" = "還沒有筆記";
+"notes.no_matching_notes" = "沒有匹配的筆記";
+"note.words" = "字";
+"note.min_read" = "分鐘閱讀";
+"note.characters" = "字元";
+
+// MARK: - 介面訊息
+"ui.create_first_note" = "建立第一條筆記";
+"ui.try_different_search" = "嘗試不同的搜尋詞";
+"ui.select_note_to_edit" = "選擇筆記進行編輯";
+"ui.choose_note_from_sidebar" = "從側邊欄選擇筆記開始";
+"ui.focus_mode" = "專注模式";
+"ui.select_note_from_toolbar" = "從工具列選擇筆記進入專注模式";
+"ui.browse_notes" = "瀏覽筆記";
+"ui.copy_something_to_see" = "複製一些內容以在此處檢視";
+
+// MARK: - 警告框按鈕
+"alert.ok" = "確定";
+"alert.reset" = "重設";
+
+// MARK: - 剪貼板視圖
+"clipboard.search.placeholder" = "搜尋剪貼板歷史...";
+"clipboard.empty.title" = "無剪貼板歷史";
+"clipboard.empty.search.title" = "沒有匹配的項目";
+"clipboard.item.image.content" = "圖片內容";
+"clipboard.item.image.dimensions" = "尺寸";
+"clipboard.item.characters" = "字元";
+"clipboard.item.pin" = "置頂";
+"clipboard.item.unpin" = "取消置頂";
+"clipboard.item.copy" = "複製到剪貼板";
+"clipboard.item.delete" = "刪除";
+"clipboard.item.expand" = "展開";
+"clipboard.item.collapse" = "收起";
+"clipboard.multi_select.enter" = "進入選擇模式";
+"clipboard.multi_select.exit" = "退出選擇模式";
+"clipboard.multi_select.delete_selected" = "刪除已選";
+"clipboard.multi_select.clear_all" = "清空全部";
+"clipboard.multi_select.items" = "項目";
+"clipboard.multi_select.selected" = "已選";
+
+// MARK: - 剪貼板過濾
+"clipboard.filter.all" = "全部";
+"clipboard.filter.text" = "文字";
+"clipboard.filter.image" = "圖片";
+"clipboard.filter.file" = "檔案";
+"clipboard.filter.today" = "今天";
+"clipboard.filter.week" = "本週";
+"clipboard.filter.month" = "本月";
+"clipboard.filter.type" = "類型";
+"clipboard.filter.source" = "來源";
+"clipboard.filter.date" = "日期";
+"clipboard.filter.select_app" = "選擇應用";
+
+// MARK: - 剪貼板排序
+"clipboard.sort.title" = "排序";
+"clipboard.sort.time" = "時間";
+"clipboard.sort.use_count" = "使用頻次";
+
+// MARK: - 剪貼板偏好設定
+"preferences.clipboard.max_age" = "最大保存時間：";
+"preferences.clipboard.days" = "天";
+"preferences.clipboard.max_age_help" = "超過此時間的剪貼板項目將被自動刪除（置頂項目會被保留）";
+"preferences.clipboard.show_use_count" = "顯示使用頻次標籤";
+"preferences.clipboard.show_use_count_help" = "在剪貼板項目上顯示使用頻次標籤";
+"preferences.clipboard.auto_cleanup" = "自動清理已啟用";
+"preferences.clipboard.auto_cleanup_help" = "自動刪除過期的剪貼板項目";

--- a/Sources/UnclutterPlus/TempFileManager.swift
+++ b/Sources/UnclutterPlus/TempFileManager.swift
@@ -256,6 +256,9 @@ class TempFileManager: ObservableObject {
             saveMetadata(for: files[index])
         }
         NSWorkspace.shared.open(file.url)
+        
+        // 触发自动隐藏窗口
+        WindowManager.shared.hideWindowAfterAction(.fileOpened)
     }
     
     func toggleSelection(_ file: TempFile) {


### PR DESCRIPTION
…自动收起\n- 来源筛选仅显示应用图标，移除名称\n- 统一尺寸/间距，增加悬停高亮与选中指示\n- 面板互斥展开，修复对齐与布局问题